### PR TITLE
bugfix: Goto Test or Test Generation popup doesn't open for python files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group =  'com.dev.testme'
-version = 1.5.1
+version = 1.5.2
 
 jvmTargetVersion = 1.6
 

--- a/src/main/java/com/weirddev/testme/intellij/action/CreateTestMeAction.java
+++ b/src/main/java/com/weirddev/testme/intellij/action/CreateTestMeAction.java
@@ -27,7 +27,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Date: 10/18/2016
@@ -108,9 +107,9 @@ public class CreateTestMeAction extends CreateTestAction {
         }
         LOG.debug("End CreateTestMeAction.invoke");
     }
-    public static void checkForTestRoots(Module srcModule, Set<VirtualFile> testFolders) {
-        CreateTestAction.checkForTestRoots(srcModule, testFolders);
-    }
+//    public static void checkForTestRoots(Module srcModule, Set<VirtualFile> testFolders) {
+//        CreateTestAction.checkForTestRoots(srcModule, testFolders);
+//    }
 
     @NotNull
     private static Module suggestModuleForTests(@NotNull Project project, @NotNull Module productionModule) {

--- a/src/main/java/com/weirddev/testme/intellij/utils/TestSubjectResolverUtils.java
+++ b/src/main/java/com/weirddev/testme/intellij/utils/TestSubjectResolverUtils.java
@@ -40,6 +40,7 @@ public class TestSubjectResolverUtils {
     }
 
     private static boolean canBeTested(PsiElement element) {
+        if (TestFinderHelper.findSourceElement(element) == null) return false;
         if (TestFinderHelper.isTest(element)) return false;
         if (Extensions.getExtensions(TestFramework.EXTENSION_NAME).length == 0) return false;
         if (element == null) return false;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>com.weirddev.testme</id>
   <name>TestMe</name>
-  <version>1.5.1</version>
+  <version>1.5.2</version>
   <vendor email="testme@weirddev.com" url="http://weirddev.com">WeirdDev</vendor>
 
   <description><![CDATA[
@@ -18,9 +18,9 @@
     ]]></description>
 
   <change-notes><![CDATA[
-        <i>Changes in v1.5.1:</i>
+        <i>Changes in v1.5.2:</i>
           <ul>
-            <li>bugfix: test params generator - Java Primitive wrappers should not be unwrapped to avoid method call ambiguity (reported by intars on June 6 '17)</li>
+            <li>bugfix: Goto Test or Test Generation popup doesn't open for python files due to internal error on testability validation check (reported by aristotll on July 30 '17)</li>
           </ul>
         <a href="http://weirddev.com/testme/release-notes">Complete Changelog</a>
     ]]>


### PR DESCRIPTION
Goto Test or Test Generation popup doesn't open for python files due to NPE error on testability validation check
reported by aristotll on July 30 '17 - http://weirddev.com/forum#!/testme:this-plugin-cause-intellij
