### PR TITLE
release v1.7  - stub mocks method class, locate concrete types of interface params, expose configuration for IDE scripting tool

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group =  'com.dev.testme'
-version = 1.6
+version = 1.7
 
 jvmTargetVersion = 1.6
 

--- a/src/integrationTest/java/com/weirddev/testme/intellij/TestMeAdditionalActionJunit4Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/TestMeAdditionalActionJunit4Test.java
@@ -26,7 +26,7 @@ public class TestMeAdditionalActionJunit4Test extends BaseIJIntegrationTest {
     }
 
     public void testInnerStaticClassWithMember() throws Exception {
-        doTest("InnerStaticClassWithMemberTest", new VisualPosition(30, 28));
+        doTest("InnerStaticClassWithMemberTest", new VisualPosition(32, 28));
     }
     public void testInnerStaticClass() throws Exception {
         doTest("InnerStaticClassTest", new VisualPosition(12, 44));

--- a/src/integrationTest/java/com/weirddev/testme/intellij/action/GotoTestOrCodeHandlerExtTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/action/GotoTestOrCodeHandlerExtTest.java
@@ -24,12 +24,6 @@ public class GotoTestOrCodeHandlerExtTest extends TestMeGeneratorTestBase {
     }
 
     @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        setTestModePropsForUI();
-    }
-
-    @Override
     protected void doTest(final String packageName, final String testSubjectClassName, final String expectedTestClassName, final boolean reformatCode, final boolean optimizeImports, final boolean replaceFqn, final boolean ignoreUnusedProperties, final int minPercentOfExcessiveSettersToPreferDefaultCtor) {
         final PsiClass fooClass = setupSourceFiles(packageName, testSubjectClassName);
         CommandProcessor.getInstance().executeCommand(getProject(), new Runnable() {

--- a/src/integrationTest/java/com/weirddev/testme/intellij/action/TestMeActionTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/action/TestMeActionTest.java
@@ -24,12 +24,6 @@ public class TestMeActionTest extends TestMeGeneratorTestBase {
         super(null, "test", Language.Java);
     }
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        setTestModePropsForUI();
-    }
-
     public void testSimpleClass() throws Exception {
         doTest();
     }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
@@ -10,6 +10,8 @@ import com.weirddev.testme.intellij.template.context.Language;
  */
 public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
 
+    public static final int MIN_PERCENT_OF_EXCESSIVE_SETTERS_TO_PREFER_DEFAULT_CTOR = 67;
+
     public TestMeGeneratorJunit4Test() {
         this(TemplateRegistry.JUNIT4_MOCKITO_JAVA_TEMPLATE, "test", Language.Java);
     }
@@ -101,15 +103,15 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
     }
     public void testIgnoreUnusedCtorArguments() throws Exception{
         skipTestIfGroovyPluginDisabled();//this tested feature does not require Groovy IJ plugin but the test cases use Groovy objects
-        doTest(true,true,true,67, true);
+        doTest(true,true,true, MIN_PERCENT_OF_EXCESSIVE_SETTERS_TO_PREFER_DEFAULT_CTOR, true);
     }
     public void testIgnoreUnusedCtorArgumentsIdentifyMethodReference() throws Exception{
         skipTestIfGroovyPluginDisabled();//this tested feature does not require Groovy IJ plugin but the test cases use Groovy objects
-        doTest(true,true,true,67, true);
+        doTest(true,true,true, MIN_PERCENT_OF_EXCESSIVE_SETTERS_TO_PREFER_DEFAULT_CTOR, true);
     }
     public void testIgnoreUnusedCtorArgumentsWhenDelegatedCalls() throws Exception{
         skipTestIfGroovyPluginDisabled();//this tested feature does not require Groovy IJ plugin but the test cases use Groovy objects
-        doTest(true,true,true,67, true);
+        doTest(true,true,true, MIN_PERCENT_OF_EXCESSIVE_SETTERS_TO_PREFER_DEFAULT_CTOR, true);
     }
 //    public void testIgnoreUnusedCtorArgumentsWhenDelegatedCallsInGroovy() throws Exception{  //todo fix different handling of array field  - BeanByCtor#myBeans - compared to testIgnoreUnusedCtorArgumentsWhenDelegatedCalls test
 //        doTest(true,true,true,67, true);
@@ -121,13 +123,16 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         skipTestIfGroovyPluginDisabled();
         //note: 2nd ctor arg passed to BeanByCtor should actually be 'new Ice()' - rather than 'null' as currently set in excepted test outcome.
         // For some reason manual tests match the expected behaviour but the UT fails. expected test has been adapted to the 'wrong' UT runtime behaviour
-        doTest(true,true,true,67, true);
+        doTest(true,true,true, MIN_PERCENT_OF_EXCESSIVE_SETTERS_TO_PREFER_DEFAULT_CTOR, true);
     }
     public void testWithFinalTypeDependency() throws Exception {
         doTest(true, true, true);
     }
     public void testReplacedInterface() throws Exception {
         doTest(true, true, true);
+    }
+   public void testMockReturned() throws Exception {
+       doTest(new FileTemplateConfig());
     }
 
 //   public void testWithFinalTypeDependencyMockable() throws Exception {

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
@@ -27,7 +27,7 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         doTest("", "Foo", "FooTest", true, false, true, false, 50);
     }
     public void testVariousFieldTypes() throws Exception {
-        final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig();
+        final FileTemplateConfig fileTemplateConfig = FileTemplateConfig.getInstance();
         fileTemplateConfig.setOptimizeImports(false);
         fileTemplateConfig.setReplaceFqn(false);
         doTest(fileTemplateConfig);
@@ -51,7 +51,7 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         doTest("", "Foo", "FooTest", true, true, true, false, 50);
     }
     public void testInheritance() throws Exception {
-        final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig();
+        final FileTemplateConfig fileTemplateConfig = FileTemplateConfig.getInstance();
         fileTemplateConfig.setReformatCode(false);
         fileTemplateConfig.setOptimizeImports(false);
         fileTemplateConfig.setReplaceFqn(false);
@@ -88,7 +88,7 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         doTest(true, true, false);
     }
     public void testParamsConstructors() throws Exception {
-        final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig();
+        final FileTemplateConfig fileTemplateConfig = FileTemplateConfig.getInstance();
         fileTemplateConfig.setReplaceInterfaceParamsWithConcreteTypes(false);
         doTest(fileTemplateConfig);
     }
@@ -139,10 +139,10 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         doTest(true, true, true);
     }
    public void testMockReturned() throws Exception {
-       doTest(new FileTemplateConfig());
+       doTest(FileTemplateConfig.getInstance());
     }
    public void testAvoidInfiniteRecursionSelfReferences() throws Exception {//todo fix issue with legitimate testable method interpreted as a getter
-       doTest(new FileTemplateConfig());
+       doTest(FileTemplateConfig.getInstance());
     }
 
 //   public void testWithFinalTypeDependencyMockable() throws Exception {

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
@@ -27,7 +27,10 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         doTest("", "Foo", "FooTest", true, false, true, false, 50);
     }
     public void testVariousFieldTypes() throws Exception {
-        doTest();
+        final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig();
+        fileTemplateConfig.setOptimizeImports(false);
+        fileTemplateConfig.setReplaceFqn(false);
+        doTest(fileTemplateConfig);
     }
     public void testWithSetters() throws Exception {
         doTest();
@@ -48,7 +51,11 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         doTest("", "Foo", "FooTest", true, true, true, false, 50);
     }
     public void testInheritance() throws Exception {
-        doTest();
+        final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig();
+        fileTemplateConfig.setReformatCode(false);
+        fileTemplateConfig.setOptimizeImports(false);
+        fileTemplateConfig.setReplaceFqn(false);
+        doTest(fileTemplateConfig);
     }
     public void testGenerics() throws Exception {
         doTest(false, false, true);
@@ -132,6 +139,9 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         doTest(true, true, true);
     }
    public void testMockReturned() throws Exception {
+       doTest(new FileTemplateConfig());
+    }
+   public void testAvoidInfiniteRecursionSelfReferences() throws Exception {//todo fix issue with legitimate testable method interpreted as a getter
        doTest(new FileTemplateConfig());
     }
 

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
@@ -1,5 +1,6 @@
 package com.weirddev.testme.intellij.generator;
 
+import com.weirddev.testme.intellij.template.FileTemplateConfig;
 import com.weirddev.testme.intellij.template.TemplateRegistry;
 import com.weirddev.testme.intellij.template.context.Language;
 
@@ -78,7 +79,9 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         doTest(true, true, false);
     }
     public void testParamsConstructors() throws Exception {
-        doTest(true, true, true);
+        final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig();
+        fileTemplateConfig.setReplaceInterfaceParamsWithConcreteTypes(false);
+        doTest(fileTemplateConfig);
     }
     public void testMiscReplacementTypes() throws Exception {
         doTest(true, true, true);
@@ -123,6 +126,10 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
     public void testWithFinalTypeDependency() throws Exception {
         doTest(true, true, true);
     }
+    public void testReplacedInterface() throws Exception {
+        doTest(true, true, true);
+    }
+
 //   public void testWithFinalTypeDependencyMockable() throws Exception {
 //       myFixture.copyDirectoryToProject("resources", "resources"); //issue with setting up a resource folder
 //        doTest(true, true, true);

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
@@ -1,5 +1,6 @@
 package com.weirddev.testme.intellij.generator;
 
+import com.weirddev.testme.intellij.template.FileTemplateConfig;
 import com.weirddev.testme.intellij.template.TemplateRegistry;
 import com.weirddev.testme.intellij.template.context.Language;
 
@@ -24,7 +25,7 @@ public class TestMeGeneratorJunit5Test extends TestMeGeneratorTestBase {
         doTest(false, false, true);
     }
     public void testMockReturned() throws Exception {
-        doTest(true, true, true);
+        doTest(new FileTemplateConfig());
     }
 
 }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
@@ -25,7 +25,7 @@ public class TestMeGeneratorJunit5Test extends TestMeGeneratorTestBase {
         doTest(false, false, true);
     }
     public void testMockReturned() throws Exception {
-        doTest(new FileTemplateConfig());
+        doTest(FileTemplateConfig.getInstance());
     }
 
 }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
@@ -23,4 +23,8 @@ public class TestMeGeneratorJunit5Test extends TestMeGeneratorTestBase {
     public void testArrays() throws Exception {
         doTest(false, false, true);
     }
+    public void testMockReturned() throws Exception {
+        doTest(true, true, true);
+    }
+
 }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorSpockTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorSpockTest.java
@@ -26,6 +26,6 @@ public class TestMeGeneratorSpockTest extends TestMeGeneratorTestBase {
         doTest(true,true,true);
     }
     public void testMockReturned() throws Exception {
-        doTest(new FileTemplateConfig());
+        doTest(FileTemplateConfig.getInstance());
     }
 }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorSpockTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorSpockTest.java
@@ -1,5 +1,6 @@
 package com.weirddev.testme.intellij.generator;
 
+import com.weirddev.testme.intellij.template.FileTemplateConfig;
 import com.weirddev.testme.intellij.template.TemplateRegistry;
 import com.weirddev.testme.intellij.template.context.Language;
 
@@ -23,5 +24,8 @@ public class TestMeGeneratorSpockTest extends TestMeGeneratorTestBase {
 
     public void testGenerics() throws Exception{
         doTest(true,true,true);
+    }
+    public void testMockReturned() throws Exception {
+        doTest(new FileTemplateConfig());
     }
 }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestBase.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestBase.java
@@ -71,7 +71,7 @@ abstract public class TestMeGeneratorTestBase extends BaseIJIntegrationTest/*Jav
     }
 
     protected void doTest(final String packageName, String testSubjectClassName, final String expectedTestClassName, final boolean reformatCode, final boolean optimizeImports, final boolean replaceFqn, final boolean ignoreUnusedProperties, final int minPercentOfExcessiveSettersToPreferDefaultCtor) {
-        doTest(packageName, testSubjectClassName, expectedTestClassName, new FileTemplateConfig(reformatCode, optimizeImports, 4, replaceFqn, ignoreUnusedProperties, true, minPercentOfExcessiveSettersToPreferDefaultCtor));
+        doTest(packageName, testSubjectClassName, expectedTestClassName, new FileTemplateConfig(reformatCode, optimizeImports, 4, replaceFqn, ignoreUnusedProperties, true, minPercentOfExcessiveSettersToPreferDefaultCtor,false));
 
     }
 

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestBase.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestBase.java
@@ -71,8 +71,7 @@ abstract public class TestMeGeneratorTestBase extends BaseIJIntegrationTest/*Jav
     }
 
     protected void doTest(final String packageName, String testSubjectClassName, final String expectedTestClassName, final boolean reformatCode, final boolean optimizeImports, final boolean replaceFqn, final boolean ignoreUnusedProperties, final int minPercentOfExcessiveSettersToPreferDefaultCtor) {
-        doTest(packageName, testSubjectClassName, expectedTestClassName, new FileTemplateConfig(reformatCode, optimizeImports, 4, replaceFqn, ignoreUnusedProperties, true, minPercentOfExcessiveSettersToPreferDefaultCtor,false));
-
+        doTest(packageName, testSubjectClassName, expectedTestClassName, new FileTemplateConfig(4, reformatCode, replaceFqn, optimizeImports, ignoreUnusedProperties, true, false, 2,minPercentOfExcessiveSettersToPreferDefaultCtor,66));
     }
 
     protected void doTest(final String packageName, String testSubjectClassName, final String expectedTestClassName, final FileTemplateConfig fileTemplateConfig) {

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestBase.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestBase.java
@@ -5,6 +5,7 @@ import com.intellij.ide.fileTemplates.FileTemplateDescriptor;
 import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.psi.*;
 import com.weirddev.testme.intellij.BaseIJIntegrationTest;
+import com.weirddev.testme.intellij.template.FileTemplateConfig;
 import com.weirddev.testme.intellij.template.FileTemplateContext;
 import com.weirddev.testme.intellij.template.context.Language;
 import org.jetbrains.annotations.NotNull;
@@ -65,12 +66,16 @@ abstract public class TestMeGeneratorTestBase extends BaseIJIntegrationTest/*Jav
     protected void doTest(boolean reformatCode, boolean optimizeImports, boolean replaceFqn, int minPercentOfExcessiveSettersToPreferDefaultCtor, boolean ignoreUnusedProperties) {
         doTest("com.example.services.impl", "Foo", "FooTest", reformatCode, optimizeImports, replaceFqn, ignoreUnusedProperties, minPercentOfExcessiveSettersToPreferDefaultCtor);
     }
-
-    protected void setTestModePropsForUI() {
-        System.setProperty("testme.popoup.center", "true");//WA swing error when popup set relative to fake test editor
+    protected void doTest(FileTemplateConfig fileTemplateConfig) {
+        doTest("com.example.services.impl", "Foo", "FooTest", fileTemplateConfig);
     }
 
     protected void doTest(final String packageName, String testSubjectClassName, final String expectedTestClassName, final boolean reformatCode, final boolean optimizeImports, final boolean replaceFqn, final boolean ignoreUnusedProperties, final int minPercentOfExcessiveSettersToPreferDefaultCtor) {
+        doTest(packageName, testSubjectClassName, expectedTestClassName, new FileTemplateConfig(reformatCode, optimizeImports, 4, replaceFqn, ignoreUnusedProperties, true, minPercentOfExcessiveSettersToPreferDefaultCtor));
+
+    }
+
+    protected void doTest(final String packageName, String testSubjectClassName, final String expectedTestClassName, final FileTemplateConfig fileTemplateConfig) {
         if (!testEnabled) {
             System.out.println("Groovy idea plugin disabled. Skipping test");
             return;
@@ -83,6 +88,7 @@ abstract public class TestMeGeneratorTestBase extends BaseIJIntegrationTest/*Jav
             @Override
             public void run() {
                 myFixture.openFileInEditor(fooClass.getContainingFile().getVirtualFile());
+
                 PsiElement result = new TestMeGenerator(new TestClassElementsLocator(), testTemplateContextBuilder,new CodeRefactorUtil()).generateTest(new FileTemplateContext(new FileTemplateDescriptor(templateFilename), language, getProject(),
                         expectedTestClassName,
                         targetPackage,
@@ -90,15 +96,13 @@ abstract public class TestMeGeneratorTestBase extends BaseIJIntegrationTest/*Jav
                         myModule,
                         srcDir,
                         fooClass,
-                        reformatCode,
-                        optimizeImports,
-                        4, replaceFqn, ignoreUnusedProperties, minPercentOfExcessiveSettersToPreferDefaultCtor));
+                        fileTemplateConfig));
                 System.out.println("result:"+result);
                 verifyGeneratedTest(packageName, expectedTestClassName);
             }
         }, CodeInsightBundle.message("intention.create.test"), this);
-
     }
+
     protected void verifyGeneratedTest(String packageName, String expectedTestClassName) {
         String expectedTestClassFilePath = (packageName.length() > 0 ? (packageName.replace(".", "/") + "/") : "") + expectedTestClassName + "."+expectedTestClassExtension;
         myFixture.checkResultByFile(/*"src/"+*/expectedTestClassFilePath, testDirectory + "/" +expectedTestClassFilePath, ignoreTrailingWhitespaces);

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestNgTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestNgTest.java
@@ -1,5 +1,6 @@
 package com.weirddev.testme.intellij.generator;
 
+import com.weirddev.testme.intellij.template.FileTemplateConfig;
 import com.weirddev.testme.intellij.template.TemplateRegistry;
 import com.weirddev.testme.intellij.template.context.Language;
 
@@ -22,5 +23,8 @@ public class TestMeGeneratorTestNgTest extends TestMeGeneratorTestBase {
     }
     public void testArrays() throws Exception {
         doTest(false, false, true);
+    }
+    public void testMockReturned() throws Exception {
+        doTest(new FileTemplateConfig());
     }
 }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestNgTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestNgTest.java
@@ -25,6 +25,6 @@ public class TestMeGeneratorTestNgTest extends TestMeGeneratorTestBase {
         doTest(false, false, true);
     }
     public void testMockReturned() throws Exception {
-        doTest(new FileTemplateConfig());
+        doTest(FileTemplateConfig.getInstance());
     }
 }

--- a/src/main/java/com/weirddev/testme/intellij/action/CreateTestMeAction.java
+++ b/src/main/java/com/weirddev/testme/intellij/action/CreateTestMeAction.java
@@ -111,7 +111,12 @@ public class CreateTestMeAction extends CreateTestAction {
             CommandProcessor.getInstance().executeCommand(project, new Runnable() {
                 @Override
                 public void run() {
-                    testMeGenerator.generateTest(new FileTemplateContext(new FileTemplateDescriptor(templateDescriptor.getFilename()),templateDescriptor.getLanguage(),project, classNameSelection.getClassName(), srcPackage, srcModule, finalTestModule,targetDirectory, srcClass, new FileTemplateConfig(true, true, FileTemplateConfig.DEFAULT_MAX_RECURSION_DEPTH, true, true, true, 50,true)));
+                    testMeGenerator.generateTest(
+                            new FileTemplateContext(
+                                    new FileTemplateDescriptor(templateDescriptor.getFilename()),templateDescriptor.getLanguage(),project, classNameSelection.getClassName(), srcPackage, srcModule, finalTestModule,targetDirectory, srcClass,
+                                    FileTemplateConfig.getInstance()
+                            )
+                    );
                 }
             }, "TestMe Generate Test", this);
         }

--- a/src/main/java/com/weirddev/testme/intellij/action/CreateTestMeAction.java
+++ b/src/main/java/com/weirddev/testme/intellij/action/CreateTestMeAction.java
@@ -22,6 +22,7 @@ import com.weirddev.testme.intellij.action.helpers.ClassNameSelection;
 import com.weirddev.testme.intellij.action.helpers.GeneratedClassNameResolver;
 import com.weirddev.testme.intellij.action.helpers.TargetDirectoryLocator;
 import com.weirddev.testme.intellij.generator.TestMeGenerator;
+import com.weirddev.testme.intellij.template.FileTemplateConfig;
 import com.weirddev.testme.intellij.template.FileTemplateContext;
 import com.weirddev.testme.intellij.template.TemplateDescriptor;
 import org.jetbrains.annotations.NotNull;
@@ -46,7 +47,6 @@ import java.util.List;
 public class CreateTestMeAction extends CreateTestAction {
     private static final Logger LOG = Logger.getInstance(CreateTestMeAction.class.getName());
     private static final String CREATE_TEST_IN_THE_SAME_ROOT = "create.test.in.the.same.root";
-    public static final int MAX_RECURSION_DEPTH = 9;
     private final TestMeGenerator testMeGenerator;
     private final GeneratedClassNameResolver generatedClassNameResolver;
     private TemplateDescriptor templateDescriptor;
@@ -111,7 +111,7 @@ public class CreateTestMeAction extends CreateTestAction {
             CommandProcessor.getInstance().executeCommand(project, new Runnable() {
                 @Override
                 public void run() {
-                    testMeGenerator.generateTest(new FileTemplateContext(new FileTemplateDescriptor(templateDescriptor.getFilename()),templateDescriptor.getLanguage(),project, classNameSelection.getClassName(), srcPackage, srcModule, finalTestModule,targetDirectory, srcClass, true, true, MAX_RECURSION_DEPTH, true, true, 50));
+                    testMeGenerator.generateTest(new FileTemplateContext(new FileTemplateDescriptor(templateDescriptor.getFilename()),templateDescriptor.getLanguage(),project, classNameSelection.getClassName(), srcPackage, srcModule, finalTestModule,targetDirectory, srcClass, new FileTemplateConfig(true, true, FileTemplateConfig.DEFAULT_MAX_RECURSION_DEPTH, true, true, true, 50)));
                 }
             }, "TestMe Generate Test", this);
         }

--- a/src/main/java/com/weirddev/testme/intellij/action/CreateTestMeAction.java
+++ b/src/main/java/com/weirddev/testme/intellij/action/CreateTestMeAction.java
@@ -111,7 +111,7 @@ public class CreateTestMeAction extends CreateTestAction {
             CommandProcessor.getInstance().executeCommand(project, new Runnable() {
                 @Override
                 public void run() {
-                    testMeGenerator.generateTest(new FileTemplateContext(new FileTemplateDescriptor(templateDescriptor.getFilename()),templateDescriptor.getLanguage(),project, classNameSelection.getClassName(), srcPackage, srcModule, finalTestModule,targetDirectory, srcClass, new FileTemplateConfig(true, true, FileTemplateConfig.DEFAULT_MAX_RECURSION_DEPTH, true, true, true, 50)));
+                    testMeGenerator.generateTest(new FileTemplateContext(new FileTemplateDescriptor(templateDescriptor.getFilename()),templateDescriptor.getLanguage(),project, classNameSelection.getClassName(), srcPackage, srcModule, finalTestModule,targetDirectory, srcClass, new FileTemplateConfig(true, true, FileTemplateConfig.DEFAULT_MAX_RECURSION_DEPTH, true, true, true, 50,true)));
                 }
             }, "TestMe Generate Test", this);
         }

--- a/src/main/java/com/weirddev/testme/intellij/generator/TestBuilderUtil.java
+++ b/src/main/java/com/weirddev/testme/intellij/generator/TestBuilderUtil.java
@@ -1,0 +1,53 @@
+package com.weirddev.testme.intellij.generator;
+
+import com.weirddev.testme.intellij.template.context.Method;
+import com.weirddev.testme.intellij.template.context.Param;
+import com.weirddev.testme.intellij.template.context.Type;
+import com.weirddev.testme.intellij.utils.ClassNameUtils;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Date: 16/09/2017
+ *
+ * @author Yaron Yamin
+ */
+public class TestBuilderUtil {
+
+    public static boolean looksLikeObjectKeyInGroovyMap(String expFragment, String canonicalTypeName) {
+        return ":".equals(expFragment) && !"java.lang.String".equals(canonicalTypeName);
+    }
+
+    public static boolean hasValidEmptyConstructor(Type type) {
+        if (type.isInterface() || type.isAbstract()) {
+            return false;
+        }
+        if (type.isHasDefaultConstructor()) {
+            return true;
+        }
+        for (Method method : type.findConstructors()) {
+            if (method.isAccessible() &&  method.getMethodParams().size() == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isValidConstructor(Type type, Method constructor, boolean hasEmptyConstructor, Map<String, String> replacementTypes) {
+        if (!constructor.isAccessible() || type.isInterface() || type.isAbstract()) return false;
+        final List<Param> methodParams = constructor.getMethodParams();
+        for (Param methodParam : methodParams) {
+            final Type methodParamType = methodParam.getType();
+            if (methodParamType.equals(type) && hasEmptyConstructor) {
+                return false;
+            }
+            //todo revise this logic - interface param might be resolved to concrete type
+            if ((methodParamType.isInterface() || methodParamType.isAbstract()) && (replacementTypes == null || replacementTypes.get(ClassNameUtils.stripGenerics(methodParamType.getCanonicalName())) == null) && hasEmptyConstructor) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/com/weirddev/testme/intellij/generator/TestMeGenerator.java
+++ b/src/main/java/com/weirddev/testme/intellij/generator/TestMeGenerator.java
@@ -8,7 +8,6 @@ import com.intellij.ide.fileTemplates.FileTemplateManager;
 import com.intellij.ide.fileTemplates.FileTemplateUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.ex.IdeDocumentHistory;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
@@ -120,14 +119,14 @@ public class TestMeGenerator {
             if (resolvedPsiElement instanceof PsiClass) {
                 PsiClass psiClass = (PsiClass) resolvedPsiElement;
                 JavaCodeStyleManager codeStyleManager = JavaCodeStyleManager.getInstance(targetDirectory.getProject());
-                if (context.isOptimizeImports()) {
+                if (context.getFileTemplateConfig().isOptimizeImports()) {
                     codeStyleManager.optimizeImports(psiClass.getContainingFile());
                 }
                 codeRefactorUtil.uncommentImports(psiClass, context.getProject());
-                if (context.isReplaceFqn()) {
+                if (context.getFileTemplateConfig().isReplaceFqn()) {
                     codeStyleManager.shortenClassReferences(psiClass);
                 }
-                if (context.isReformatCode()) {
+                if (context.getFileTemplateConfig().isReformatCode()) {
                     final PsiFile containingFile = psiClass.getContainingFile();
                     final TextRange textRange = containingFile.getTextRange();
                     CodeStyleManager.getInstance(context.getProject()).reformatText(containingFile, textRange.getStartOffset(), textRange.getEndOffset());

--- a/src/main/java/com/weirddev/testme/intellij/generator/TestTemplateContextBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/generator/TestTemplateContextBuilder.java
@@ -45,13 +45,13 @@ public class TestTemplateContextBuilder {
             }
         }
         logger.debug("Resolved internal references in test template context");
-        ctxtParams.put(TestMeTemplateParams.MOCKITO_UTILS, createMockitoUtils(context));
+        ctxtParams.put(TestMeTemplateParams.MOCKITO_MOCK_BUILDER, createMockitoMockBuilder(context));
         logger.debug("Done building Test Template context in "+(new Date().getTime()-start)+" millis");
         return ctxtParams;
     }
 
     @NotNull
-    private MockitoUtils createMockitoUtils(FileTemplateContext context) {
+    private MockitoMockBuilder createMockitoMockBuilder(FileTemplateContext context) {
         boolean found = false;
 //        final VirtualFile mockMakerVFile = ResourceFileUtil.findResourceFileInScope("mockito-extensions/org.mockito.plugins.MockMaker", context.getProject(), context.getTestModule().getModuleWithDependenciesAndLibrariesScope(true));
         final VirtualFile mockMakerVFile = ResourceFileUtil.findResourceFileInDependents(context.getTestModule(), "mockito-extensions/org.mockito.plugins.MockMaker");
@@ -65,7 +65,7 @@ public class TestTemplateContextBuilder {
                 logger.debug("is mock-maker-inline turned on:"+ found);
             }
         }
-        return new MockitoUtils(found);
+        return new MockitoMockBuilder(found,context.getFileTemplateConfig().isStubMockMethodCallsReturnValues());
     }
 
     void populateDateFields(Map<String, Object> ctxtParams, Calendar calendar) {

--- a/src/main/java/com/weirddev/testme/intellij/generator/TestTemplateContextBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/generator/TestTemplateContextBuilder.java
@@ -29,15 +29,15 @@ public class TestTemplateContextBuilder {
         populateDateFields(ctxtParams, Calendar.getInstance());
         ctxtParams.put(TestMeTemplateParams.CLASS_NAME, context.getTargetClass());
         ctxtParams.put(TestMeTemplateParams.PACKAGE_NAME, context.getTargetPackage().getQualifiedName());
-        int maxRecursionDepth = context.getMaxRecursionDepth();
+        int maxRecursionDepth = context.getFileTemplateConfig().getMaxRecursionDepth();
         ctxtParams.put(TestMeTemplateParams.MAX_RECURSION_DEPTH, maxRecursionDepth);
-        ctxtParams.put(TestMeTemplateParams.TEST_BUILDER, new TestBuilderImpl(context.getLanguage(),maxRecursionDepth, context.isIgnoreUnusedProperties(), context.getMinPercentOfExcessiveSettersToPreferDefaultCtor()));
         ctxtParams.put(TestMeTemplateParams.STRING_UTILS, new StringUtils());
         ctxtParams.put(TestMeTemplateParams.TEST_SUBJECT_UTILS,new TestSubjectUtils());
+        final TypeDictionary typeDictionary = new TypeDictionary(context.getSrcClass(), context.getTargetPackage());
+        ctxtParams.put(TestMeTemplateParams.TEST_BUILDER, new TestBuilderImpl(context.getLanguage(), context.getSrcModule(), typeDictionary, context.getFileTemplateConfig()));
         final PsiClass targetClass = context.getSrcClass();
         if (targetClass != null && targetClass.isValid()) {
             ctxtParams.put(TestMeTemplateParams.TESTED_CLASS_LANGUAGE, targetClass.getLanguage().getID());
-            final TypeDictionary typeDictionary = new TypeDictionary(context.getSrcClass(), context.getTargetPackage());
             final Type type = typeDictionary.getType(Type.resolveType(targetClass), maxRecursionDepth, true);
             ctxtParams.put(TestMeTemplateParams.TESTED_CLASS, type);
             if (type != null) {

--- a/src/main/java/com/weirddev/testme/intellij/template/FileTemplateConfig.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/FileTemplateConfig.java
@@ -1,0 +1,109 @@
+package com.weirddev.testme.intellij.template;
+
+/**
+ * Date: 25/09/2017
+ *
+ * @author Yaron Yamin
+ */
+public class FileTemplateConfig {
+    public static final int DEFAULT_MAX_RECURSION_DEPTH = 9;
+    private int maxRecursionDepth = DEFAULT_MAX_RECURSION_DEPTH;
+    private boolean reformatCode = true;
+    private boolean optimizeImports = true;
+    private boolean replaceFqn = true;
+    /**
+     * do not invoke setter or getter for a property not used in tested method
+     */
+    private boolean ignoreUnusedProperties = true;
+    /**
+     * replace interface/abstract argument types with concrete types if exists in project. otherwise pass null.
+     */
+    private boolean replaceInterfaceParamsWithConcreteTypes = true;
+    /**
+     * Relevant when shouldIgnoreUnusedProperties is true. When the minimum percentage of all interactions with constructed type are via setters/getters or direct property field read/assignment - then the type is considered as a 'data' bean,
+     * so a null value is passed for any constructor argument that is bound to a field in the constructed type which is not used in the tested method
+     */
+    private int minPercentOfExcessiveSettersToPreferMapCtor = 50;
+    /**
+     * Relevant when shouldIgnoreUnusedProperties is true. When the minimum percentage of all interactions with constructed type are via setters/getters or direct property field read/assignment - then the type is considered as a 'data' bean,
+     * so a null value is passed for any constructor argument that is bound to a field in the constructed type which is not used in the tested method
+     */
+    protected int minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization = 66;
+
+    public FileTemplateConfig() { }
+
+    public FileTemplateConfig(boolean reformatCode, boolean optimizeImports, int maxRecursionDepth, boolean replaceFqn, boolean ignoreUnusedProperties, boolean replaceInterfaceParamsWithConcreteTypes, int
+            minPercentOfExcessiveSettersToPreferMapCtor) {
+        this.reformatCode = reformatCode;
+        this.optimizeImports = optimizeImports;
+        this.maxRecursionDepth = maxRecursionDepth;
+        this.replaceFqn = replaceFqn;
+        this.ignoreUnusedProperties = ignoreUnusedProperties;
+        this.replaceInterfaceParamsWithConcreteTypes = replaceInterfaceParamsWithConcreteTypes;
+        this.minPercentOfExcessiveSettersToPreferMapCtor = minPercentOfExcessiveSettersToPreferMapCtor;
+    }
+
+    public boolean isReformatCode() {
+        return reformatCode;
+    }
+
+    public boolean isOptimizeImports() {
+        return optimizeImports;
+    }
+
+    public int getMaxRecursionDepth() {
+        return maxRecursionDepth;
+    }
+
+    public boolean isReplaceFqn() {
+        return replaceFqn;
+    }
+
+    public boolean isIgnoreUnusedProperties() {
+        return ignoreUnusedProperties;
+    }
+
+    public boolean isReplaceInterfaceParamsWithConcreteTypes() {
+        return replaceInterfaceParamsWithConcreteTypes;
+    }
+
+    public int getMinPercentOfExcessiveSettersToPreferMapCtor() {
+        return minPercentOfExcessiveSettersToPreferMapCtor;
+    }
+
+    public void setMaxRecursionDepth(int maxRecursionDepth) {
+        this.maxRecursionDepth = maxRecursionDepth;
+    }
+
+    public void setReformatCode(boolean reformatCode) {
+        this.reformatCode = reformatCode;
+    }
+
+    public void setOptimizeImports(boolean optimizeImports) {
+        this.optimizeImports = optimizeImports;
+    }
+
+    public void setReplaceFqn(boolean replaceFqn) {
+        this.replaceFqn = replaceFqn;
+    }
+
+    public void setIgnoreUnusedProperties(boolean ignoreUnusedProperties) {
+        this.ignoreUnusedProperties = ignoreUnusedProperties;
+    }
+
+    public void setReplaceInterfaceParamsWithConcreteTypes(boolean replaceInterfaceParamsWithConcreteTypes) {
+        this.replaceInterfaceParamsWithConcreteTypes = replaceInterfaceParamsWithConcreteTypes;
+    }
+
+    public void setMinPercentOfExcessiveSettersToPreferMapCtor(int minPercentOfExcessiveSettersToPreferMapCtor) {
+        this.minPercentOfExcessiveSettersToPreferMapCtor = minPercentOfExcessiveSettersToPreferMapCtor;
+    }
+
+    public int getMinPercentOfInteractionWithPropertiesToTriggerConstructorOptimization() {
+        return minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization;
+    }
+
+    public void setMinPercentOfInteractionWithPropertiesToTriggerConstructorOptimization(int minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization) {
+        this.minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization = minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization;
+    }
+}

--- a/src/main/java/com/weirddev/testme/intellij/template/FileTemplateConfig.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/FileTemplateConfig.java
@@ -7,42 +7,103 @@ package com.weirddev.testme.intellij.template;
  */
 public class FileTemplateConfig {
     public static final int DEFAULT_MAX_RECURSION_DEPTH = 9;
+    /**
+     * Test parameters generator feature. limit the maximum depth of recursive nested parameters initialization and recursion of tested class structure inspection.
+     * Warning: raising this value above 9 may result in severe performance degradation during test generation, to a point where the IDE is not responsive for over a minute.
+     * Valid values:1-20
+     * Default:9
+     */
     private int maxRecursionDepth = DEFAULT_MAX_RECURSION_DEPTH;
+    /**
+     * Test generator styling feature. reformat generated test code according to relevant language styling settings in IDEA
+     * Valid values:true,false
+     * Default:true
+     */
     private boolean reformatCode = true;
-    private boolean optimizeImports = true;
+    /**
+     * Test generator styling feature. replace fully qualified class names with import statements where possible in generated test
+     * Valid values:true,false
+     * Default:true
+     */
     private boolean replaceFqn = true;
+    /**
+     * Test generator styling feature. optimize imports in generated test
+     * Valid values:true,false
+     * Default:true
+     */
+    private boolean optimizeImports = true;
+    /**
+     * Test mocks generator feature. generate mocked method call response in case mocks that return a value are called by the tested method and the calling code is part of the tested method
+     * Valid values:true,false
+     * Default:true
+     */
     private boolean stubMockMethodCallsReturnValues = true;
     /**
-     * do not invoke setter or getter for a property not used in tested method
+     * Test parameters generator optimization. when true - heuristically identify and ignore unused properties by the tested method, so null is passed for constructor arguments that initialize unused properties. In case a Groovy map constructor used - property will not be initialized
+     * Valid values:true,false
+     * Default:true
      */
     private boolean ignoreUnusedProperties = true;
     /**
-     * replace interface/abstract argument types with concrete types if exists in project. otherwise pass null.
+     * Test parameters generator feature.replace interface/abstract argument types with concrete types if exists in project. otherwise pass null.
+     * Valid values:true,false
+     * Default:true
      */
     private boolean replaceInterfaceParamsWithConcreteTypes = true;
+
     /**
-     * Relevant when shouldIgnoreUnusedProperties is true. When the minimum percentage of all interactions with constructed type are via setters/getters or direct property field read/assignment - then the type is considered as a 'data' bean,
-     * so a null value is passed for any constructor argument that is bound to a field in the constructed type which is not used in the tested method
+     * Test parameters generator feature. only relevant when replaceInterfaceParamsWithConcreteTypes is true.
+     * If the number of concrete implementations found in project sources is over this limit - then Interface param will not be initialized. otherwise a random selection of the found concrete types will be used.
+     * This ia a heuristic number, assuming too many implementations is an indicator to an interface that is too generic (i.e. comparator) - so an arbitrary implementation should not be selected in such case
+     * Valid values:1-100
+     * Default:2
+     */
+    private int maxNumOfConcreteCandidatesToReplaceInterfaceParam = 2;
+    /**
+     * Test parameters generator optimization. Relevant for Groovy tests.
+     * When the amount of a given type setters exceeds by this percentage value over of the number of arguments in the type's biggest constructor ( constructor that has the maximum number of arguments) - then a map constructor is used to initialize the type.
+     * If the type's biggest constructor has 0 arguments - map constructor will be used anyway if possible
+     * Valid values:0-100
+     * Default:50
      */
     private int minPercentOfExcessiveSettersToPreferMapCtor = 50;
     /**
      * Relevant when shouldIgnoreUnusedProperties is true. When the minimum percentage of all interactions with constructed type are via setters/getters or direct property field read/assignment - then the type is considered as a 'data' bean,
-     * so a null value is passed for any constructor argument that is bound to a field in the constructed type which is not used in the tested method
+     * so a null value is passed for any constructor argument that is bound to a field in the constructed type which is not used in the tested method. in case a map constructor being used - than the property will not be initialized.
+     * Valid values:0-100
+     * Default:66
      */
-    protected int minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization = 66;
+    private int minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization = 66;
 
     public FileTemplateConfig() { }
+    public static FileTemplateConfig getInstance()  {
+        return new FileTemplateConfig(
+                Integer.valueOf(System.getProperties().getProperty("testMe.generator.maxRecursionDepth", FileTemplateConfig.DEFAULT_MAX_RECURSION_DEPTH + "")),
+                Boolean.valueOf(System.getProperties().getProperty("testMe.style.reformatCode", "true")),
+                Boolean.valueOf(System.getProperties().getProperty("testMe.style.replaceFqn", "true")),
+                Boolean.valueOf(System.getProperties().getProperty("testMe.style.optimizeImports", "true")),
+                Boolean.valueOf(System.getProperties().getProperty("testMe.generator.ignoreUnusedProperties", "true")),
+                Boolean.valueOf(System.getProperties().getProperty("testMe.generator.replaceInterfaceParamsWithConcreteTypes", "true")),
+                Boolean.valueOf(System.getProperties().getProperty("testMe.generator.stubMockMethodCallsReturnValues", "true")),
+                Integer.valueOf(System.getProperties().getProperty("testMe.generator.maxNumOfConcreteCandidatesToReplaceInterfaceParam", "2")),
+                Integer.valueOf(System.getProperties().getProperty("testMe.generator.minPercentOfExcessiveSettersToPreferMapCtor", "50")),
+                Integer.valueOf(System.getProperties().getProperty("testMe.generator.minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization", "66"))
+        );
 
-    public FileTemplateConfig(boolean reformatCode, boolean optimizeImports, int maxRecursionDepth, boolean replaceFqn, boolean ignoreUnusedProperties, boolean replaceInterfaceParamsWithConcreteTypes, int
-            minPercentOfExcessiveSettersToPreferMapCtor,boolean stubMockMethodCallsReturnValues) {
-        this.reformatCode = reformatCode;
-        this.optimizeImports = optimizeImports;
+    }
+
+    public FileTemplateConfig(int maxRecursionDepth, boolean reformatCode, boolean replaceFqn, boolean optimizeImports, boolean ignoreUnusedProperties, boolean replaceInterfaceParamsWithConcreteTypes, boolean stubMockMethodCallsReturnValues,
+                              int maxNumOfConcreteCandidatesToReplaceInterfaceParam, int minPercentOfExcessiveSettersToPreferMapCtor, int minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization) {
         this.maxRecursionDepth = maxRecursionDepth;
+        this.reformatCode = reformatCode;
         this.replaceFqn = replaceFqn;
+        this.optimizeImports = optimizeImports;
+        this.stubMockMethodCallsReturnValues = stubMockMethodCallsReturnValues;
         this.ignoreUnusedProperties = ignoreUnusedProperties;
         this.replaceInterfaceParamsWithConcreteTypes = replaceInterfaceParamsWithConcreteTypes;
+        this.maxNumOfConcreteCandidatesToReplaceInterfaceParam = maxNumOfConcreteCandidatesToReplaceInterfaceParam;
         this.minPercentOfExcessiveSettersToPreferMapCtor = minPercentOfExcessiveSettersToPreferMapCtor;
-        this.stubMockMethodCallsReturnValues = stubMockMethodCallsReturnValues;
+        this.minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization = minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization;
     }
 
     public boolean isReformatCode() {
@@ -89,10 +150,6 @@ public class FileTemplateConfig {
         this.replaceFqn = replaceFqn;
     }
 
-    public void setIgnoreUnusedProperties(boolean ignoreUnusedProperties) {
-        this.ignoreUnusedProperties = ignoreUnusedProperties;
-    }
-
     public void setReplaceInterfaceParamsWithConcreteTypes(boolean replaceInterfaceParamsWithConcreteTypes) {
         this.replaceInterfaceParamsWithConcreteTypes = replaceInterfaceParamsWithConcreteTypes;
     }
@@ -113,7 +170,7 @@ public class FileTemplateConfig {
         return stubMockMethodCallsReturnValues;
     }
 
-    public void setStubMockMethodCallsReturnValues(boolean stubMockMethodCallsReturnValues) {
-        this.stubMockMethodCallsReturnValues = stubMockMethodCallsReturnValues;
+    public int getMaxNumOfConcreteCandidatesToReplaceInterfaceParam() {
+        return maxNumOfConcreteCandidatesToReplaceInterfaceParam;
     }
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/FileTemplateConfig.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/FileTemplateConfig.java
@@ -58,7 +58,7 @@ public class FileTemplateConfig {
      * Valid values:1-100
      * Default:2
      */
-    private int maxNumOfConcreteCandidatesToReplaceInterfaceParam = 2;
+    private int maxNumOfConcreteCandidatesToReplaceInterfaceParam = 5;
     /**
      * Test parameters generator optimization. Relevant for Groovy tests.
      * When the amount of a given type setters exceeds by this percentage value over of the number of arguments in the type's biggest constructor ( constructor that has the maximum number of arguments) - then a map constructor is used to initialize the type.
@@ -85,7 +85,7 @@ public class FileTemplateConfig {
                 Boolean.valueOf(System.getProperties().getProperty("testMe.generator.ignoreUnusedProperties", "true")),
                 Boolean.valueOf(System.getProperties().getProperty("testMe.generator.replaceInterfaceParamsWithConcreteTypes", "true")),
                 Boolean.valueOf(System.getProperties().getProperty("testMe.generator.stubMockMethodCallsReturnValues", "true")),
-                Integer.valueOf(System.getProperties().getProperty("testMe.generator.maxNumOfConcreteCandidatesToReplaceInterfaceParam", "2")),
+                Integer.valueOf(System.getProperties().getProperty("testMe.generator.maxNumOfConcreteCandidatesToReplaceInterfaceParam", "5")),
                 Integer.valueOf(System.getProperties().getProperty("testMe.generator.minPercentOfExcessiveSettersToPreferMapCtor", "50")),
                 Integer.valueOf(System.getProperties().getProperty("testMe.generator.minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization", "66"))
         );

--- a/src/main/java/com/weirddev/testme/intellij/template/FileTemplateConfig.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/FileTemplateConfig.java
@@ -11,6 +11,7 @@ public class FileTemplateConfig {
     private boolean reformatCode = true;
     private boolean optimizeImports = true;
     private boolean replaceFqn = true;
+    private boolean stubMockMethodCallsReturnValues = true;
     /**
      * do not invoke setter or getter for a property not used in tested method
      */
@@ -33,7 +34,7 @@ public class FileTemplateConfig {
     public FileTemplateConfig() { }
 
     public FileTemplateConfig(boolean reformatCode, boolean optimizeImports, int maxRecursionDepth, boolean replaceFqn, boolean ignoreUnusedProperties, boolean replaceInterfaceParamsWithConcreteTypes, int
-            minPercentOfExcessiveSettersToPreferMapCtor) {
+            minPercentOfExcessiveSettersToPreferMapCtor,boolean stubMockMethodCallsReturnValues) {
         this.reformatCode = reformatCode;
         this.optimizeImports = optimizeImports;
         this.maxRecursionDepth = maxRecursionDepth;
@@ -41,6 +42,7 @@ public class FileTemplateConfig {
         this.ignoreUnusedProperties = ignoreUnusedProperties;
         this.replaceInterfaceParamsWithConcreteTypes = replaceInterfaceParamsWithConcreteTypes;
         this.minPercentOfExcessiveSettersToPreferMapCtor = minPercentOfExcessiveSettersToPreferMapCtor;
+        this.stubMockMethodCallsReturnValues = stubMockMethodCallsReturnValues;
     }
 
     public boolean isReformatCode() {
@@ -105,5 +107,13 @@ public class FileTemplateConfig {
 
     public void setMinPercentOfInteractionWithPropertiesToTriggerConstructorOptimization(int minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization) {
         this.minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization = minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization;
+    }
+
+    public boolean isStubMockMethodCallsReturnValues() {
+        return stubMockMethodCallsReturnValues;
+    }
+
+    public void setStubMockMethodCallsReturnValues(boolean stubMockMethodCallsReturnValues) {
+        this.stubMockMethodCallsReturnValues = stubMockMethodCallsReturnValues;
     }
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/FileTemplateContext.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/FileTemplateContext.java
@@ -23,14 +23,9 @@ public class FileTemplateContext {
     private final Module testModule;
     private final PsiDirectory targetDirectory;
     private final PsiClass srcClass;
-    private final boolean reformatCode;
-    private final boolean optimizeImports;
-    private final int maxRecursionDepth;
-    private final boolean replaceFqn;
-    private final boolean ignoreUnusedProperties;
-    private final int minPercentOfExcessiveSettersToPreferDefaultCtor;
+    private final FileTemplateConfig fileTemplateConfig;
 
-    public FileTemplateContext(FileTemplateDescriptor fileTemplateDescriptor, Language language, Project project, String targetClass, PsiPackage targetPackage, Module srcModule, Module testModule, PsiDirectory targetDirectory, PsiClass srcClass, boolean reformatCode, boolean optimizeImports, int maxRecursionDepth, boolean replaceFqn, boolean ignoreUnusedProperties, int minPercentOfExcessiveSettersToPreferDefaultCtor) {
+    public FileTemplateContext(FileTemplateDescriptor fileTemplateDescriptor, Language language, Project project, String targetClass, PsiPackage targetPackage, Module srcModule, Module testModule, PsiDirectory targetDirectory, PsiClass srcClass, FileTemplateConfig fileTemplateConfig) {
         this.fileTemplateDescriptor = fileTemplateDescriptor;
         this.language = language;
         this.project = project;
@@ -40,12 +35,7 @@ public class FileTemplateContext {
         this.testModule = testModule;
         this.targetDirectory = targetDirectory;
         this.srcClass = srcClass;
-        this.reformatCode = reformatCode;
-        this.optimizeImports = optimizeImports;
-        this.maxRecursionDepth = maxRecursionDepth;
-        this.replaceFqn = replaceFqn;
-        this.ignoreUnusedProperties = ignoreUnusedProperties;
-        this.minPercentOfExcessiveSettersToPreferDefaultCtor = minPercentOfExcessiveSettersToPreferDefaultCtor;
+        this.fileTemplateConfig = fileTemplateConfig;
     }
 
     public Project getProject() {
@@ -75,36 +65,15 @@ public class FileTemplateContext {
     public FileTemplateDescriptor getFileTemplateDescriptor() {
         return fileTemplateDescriptor;
     }
-
-    public boolean isReformatCode() {
-        return reformatCode;
-    }
-
-    public boolean isOptimizeImports() {
-        return optimizeImports;
-    }
-
-    public int getMaxRecursionDepth() {
-        return maxRecursionDepth;
-    }
-
-    public boolean isReplaceFqn() {
-        return replaceFqn;
-    }
-
-    public boolean isIgnoreUnusedProperties() {
-        return ignoreUnusedProperties;
-    }
-
-    public int getMinPercentOfExcessiveSettersToPreferDefaultCtor() {
-        return minPercentOfExcessiveSettersToPreferDefaultCtor;
-    }
-
     public Language getLanguage() {
         return language;
     }
 
     public Module getTestModule() {
         return testModule;
+    }
+
+    public FileTemplateConfig getFileTemplateConfig() {
+        return fileTemplateConfig;
     }
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/LangTestBuilderFactory.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/LangTestBuilderFactory.java
@@ -1,26 +1,30 @@
 package com.weirddev.testme.intellij.template;
 
+import com.intellij.openapi.module.Module;
 import com.weirddev.testme.intellij.template.context.*;
 import org.jetbrains.annotations.NotNull;
 
 public class LangTestBuilderFactory {
-    private final boolean shouldIgnoreUnusedProperties;
     private Language language;
-    private int maxRecursionDepth;
+    private FileTemplateConfig fileTemplateConfig;
+    private Module srcModule;
+    private TypeDictionary typeDictionary;
 
-    public LangTestBuilderFactory(Language language, int maxRecursionDepth, boolean shouldIgnoreUnusedProperties) {
+    public LangTestBuilderFactory(Language language, Module srcModule, FileTemplateConfig fileTemplateConfig, TypeDictionary typeDictionary) {
         this.language = language;
-        this.maxRecursionDepth = maxRecursionDepth;
-        this.shouldIgnoreUnusedProperties = shouldIgnoreUnusedProperties;
+        this.fileTemplateConfig = fileTemplateConfig;
+        this.srcModule = srcModule;
+        this.typeDictionary = typeDictionary;
     }
 
     @NotNull
-    public LangTestBuilder createTestBuilder(Method method, TestBuilder.ParamRole paramRole, int minPercentOfExcessiveSettersToPreferDefaultCtor) throws Exception {
+    public LangTestBuilder createTestBuilder(Method method, TestBuilder.ParamRole paramRole) throws Exception {
         LangTestBuilder langTestBuilder;
         if ( language==Language.Groovy) {
-            langTestBuilder = new GroovyTestBuilderImpl(maxRecursionDepth, method, shouldIgnoreUnusedProperties, paramRole, minPercentOfExcessiveSettersToPreferDefaultCtor, 66); //todo add replacementTypes, defaultTypeValues and testBuilder as members
+            //todo add replacementTypes, defaultTypeValues and testBuilder as members
+            langTestBuilder = new GroovyTestBuilderImpl(method, paramRole,fileTemplateConfig, srcModule,typeDictionary);
         } else{
-            langTestBuilder = new JavaTestBuilderImpl(maxRecursionDepth, method, shouldIgnoreUnusedProperties, paramRole, 66);
+            langTestBuilder = new JavaTestBuilderImpl(method, paramRole, fileTemplateConfig, srcModule,typeDictionary);
         }
         return langTestBuilder;
     }

--- a/src/main/java/com/weirddev/testme/intellij/template/TypeDictionary.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/TypeDictionary.java
@@ -49,6 +49,6 @@ public class TypeDictionary {
     }
 
     public boolean isAccessible(PsiMethod psiMethod) {
-        return PsiUtil.isAccessibleFromPackage(psiMethod, targetPackage);
+        return PsiUtil.isAccessibleFromPackage(psiMethod, targetPackage) && (psiMethod.getContainingClass()==null || PsiUtil.isAccessibleFromPackage(psiMethod.getContainingClass(), targetPackage));
     }
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/TypeDictionary.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/TypeDictionary.java
@@ -36,13 +36,13 @@ public class TypeDictionary {
         if (psiType != null) {
             final String canonicalText = psiType.getCanonicalText();
             type = typeDictionary.get(canonicalText);
-            if (type == null || !type.isDependenciesResolvable() && maxRecursionDepth>1) {
-                LOG.debug(newTypeCounter.incrementAndGet()+". Creating new type object for:" + canonicalText);
-                type = new Type(psiType, this, maxRecursionDepth);
+            if (type == null || !type.isDependenciesResolvable() && shouldResolveAllMethods && maxRecursionDepth>1) {
+                LOG.debug(newTypeCounter.incrementAndGet()+". Creating new type object for:" + canonicalText+" maxRecursionDepth:"+maxRecursionDepth);
+                type = new Type(psiType, this, maxRecursionDepth,shouldResolveAllMethods);
                 typeDictionary.put(canonicalText, type);
                 type.resolveDependencies(this,maxRecursionDepth, psiType,shouldResolveAllMethods);
             } else {
-                LOG.debug(existingTypeHitsCounter.incrementAndGet()+". Found existing type object for:" + canonicalText);
+                LOG.debug(existingTypeHitsCounter.incrementAndGet()+". Found existing type object for:" + canonicalText+" maxRecursionDepth:"+maxRecursionDepth);
             }
         }
         return type;

--- a/src/main/java/com/weirddev/testme/intellij/template/TypeDictionary.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/TypeDictionary.java
@@ -36,7 +36,7 @@ public class TypeDictionary {
         if (psiType != null) {
             final String canonicalText = psiType.getCanonicalText();
             type = typeDictionary.get(canonicalText);
-            if (type == null || !type.isDependenciesResolvable()) {
+            if (type == null || !type.isDependenciesResolvable() && maxRecursionDepth>1) {
                 LOG.debug(newTypeCounter.incrementAndGet()+". Creating new type object for:" + canonicalText);
                 type = new Type(psiType, this, maxRecursionDepth);
                 typeDictionary.put(canonicalText, type);

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Field.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Field.java
@@ -31,7 +31,7 @@ public class Field {
 
     public Type buildType(PsiType type, TypeDictionary typeDictionary, int maxRecursionDepth) {
         if (typeDictionary == null) {
-            return new Type(type, null, 0);
+            return new Type(type, null, 0, false);
         } else {
             return typeDictionary.getType(type, maxRecursionDepth, true);
         }

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Field.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Field.java
@@ -3,6 +3,8 @@ package com.weirddev.testme.intellij.template.context;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiType;
+import com.weirddev.testme.intellij.template.TypeDictionary;
 import com.weirddev.testme.intellij.utils.ClassNameUtils;
 
 /**
@@ -17,15 +19,24 @@ public class Field {
     private final String ownerClassCanonicalName;
     private String name;
 
-    public Field(PsiField psiField, PsiClass srcClass) {
+    public Field(PsiField psiField, PsiClass srcClass, TypeDictionary typeDictionary, int maxRecursionDepth) {
         this.name = psiField.getName();
-        type = new Type(psiField.getType(), null, 0);
+        type= buildType(psiField.getType(), typeDictionary, maxRecursionDepth);
         String canonicalText = srcClass.getQualifiedName();
         ownerClassCanonicalName = ClassNameUtils.stripArrayVarargsDesignator(canonicalText);
         overridden = isOverriddenInChild(psiField, srcClass);
         isFinal = psiField.getModifierList() != null && psiField.getModifierList().hasExplicitModifier(PsiModifier.FINAL);
         isStatic = psiField.getModifierList() != null && psiField.getModifierList().hasExplicitModifier(PsiModifier.STATIC);
     }
+
+    public Type buildType(PsiType type, TypeDictionary typeDictionary, int maxRecursionDepth) {
+        if (typeDictionary == null) {
+            return new Type(type, null, 0);
+        } else {
+            return typeDictionary.getType(type, maxRecursionDepth, true);
+        }
+    }
+
     private boolean isOverriddenInChild(PsiField psiField, PsiClass srcClass) {
         String srcQualifiedName = srcClass.getQualifiedName();
         String fieldClsQualifiedName = psiField.getContainingClass()==null?null:psiField.getContainingClass().getQualifiedName();

--- a/src/main/java/com/weirddev/testme/intellij/template/context/GroovyTestBuilderImpl.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/GroovyTestBuilderImpl.java
@@ -48,9 +48,15 @@ public class GroovyTestBuilderImpl extends JavaTestBuilderImpl {
             if (isNonStaticNestedClass) {
                 final Node<Param> parentContainerNode = new Node<Param>(new SyntheticParam(parentContainerClass, parentContainerClass.getName(), false), null, ownerParamNode.getDepth());
                 buildCallParam(replacementTypes, defaultTypeValues, testBuilder,parentContainerNode);
-                testBuilder.append(",");
+                testBuilder.append(PARAMS_SEPARATOR);
             }
+            final int origLength = testBuilder.length();
             super.buildCallParams(constructor,params, replacementTypes, defaultTypeValues, testBuilder, ownerParamNode);
+            if (isNonStaticNestedClass) {
+                if (origLength == testBuilder.length()) {
+                    testBuilder.delete(testBuilder.length() - PARAMS_SEPARATOR.length(),testBuilder.length());
+                }
+            }
         } else if(ownerParamNode.getData()!=null){
             List<SyntheticParam> syntheticParams = findProperties(ownerParamNode.getData().getType());
             if (syntheticParams.size() > 0) {

--- a/src/main/java/com/weirddev/testme/intellij/template/context/GroovyTestBuilderImpl.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/GroovyTestBuilderImpl.java
@@ -1,6 +1,9 @@
 package com.weirddev.testme.intellij.template.context;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.weirddev.testme.intellij.template.FileTemplateConfig;
+import com.weirddev.testme.intellij.template.TypeDictionary;
 import com.weirddev.testme.intellij.utils.Node;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,16 +20,9 @@ import java.util.Map;
  */
 public class GroovyTestBuilderImpl extends JavaTestBuilderImpl {
     private static final Logger LOG = Logger.getInstance(GroovyTestBuilderImpl.class.getName());
-    /**
-     * If constructed type has more than this minimum percentage of setters over number of arguments in biggest constructor and default constructor is accessible
-     * then initialize the type with default constructor and setters (map constructor) instead of biggest constructor
-     */
-    private final int minPercentOfExcessiveSettersToPreferDefaultCtor;
 
-    public GroovyTestBuilderImpl(int maxRecursionDepth, Method method, boolean shouldIgnoreUnusedProperties, TestBuilder.ParamRole paramRole, int minPercentOfExcessiveSettersToPreferDefaultCtor, int
-            minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization) {
-        super(maxRecursionDepth, method,shouldIgnoreUnusedProperties,paramRole,minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization);
-        this.minPercentOfExcessiveSettersToPreferDefaultCtor = minPercentOfExcessiveSettersToPreferDefaultCtor;
+    public GroovyTestBuilderImpl(Method method, TestBuilder.ParamRole paramRole, FileTemplateConfig fileTemplateConfig, Module srcModule, TypeDictionary typeDictionary) {
+        super(method, paramRole, fileTemplateConfig, srcModule, typeDictionary);
     }
 
     @Override
@@ -118,7 +114,7 @@ public class GroovyTestBuilderImpl extends JavaTestBuilderImpl {
     }
 
     boolean shouldPreferSettersOverCtor(int noOfCtorArgs, int noOfSetters) {
-        return 0 < noOfSetters && (noOfCtorArgs * ((minPercentOfExcessiveSettersToPreferDefaultCtor + 100f) / 100f) <= ((float)noOfSetters) );
+        return 0 < noOfSetters && (noOfCtorArgs * ((fileTemplateConfig.getMinPercentOfExcessiveSettersToPreferMapCtor() + 100f) / 100f) <= ((float)noOfSetters) );
     }
 
     private int countSetters(Type type) {

--- a/src/main/java/com/weirddev/testme/intellij/template/context/JavaTestBuilderImpl.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/JavaTestBuilderImpl.java
@@ -28,7 +28,7 @@ import java.util.Map;
 public class JavaTestBuilderImpl implements LangTestBuilder {
     private static final Logger LOG = Logger.getInstance(JavaTestBuilderImpl.class.getName());
     private static Type DEFAULT_TYPE = new Type("java.lang.String", "String", "java.lang", false, false, false, false, false, new ArrayList<Type>());
-    private static final String PARAMS_SEPARATOR = ", ";
+    protected static final String PARAMS_SEPARATOR = ", ";
     private final TestBuilder.ParamRole paramRole; //todo consider removing. not used anymore
     private final Method testedMethod;
     private Module srcModule;

--- a/src/main/java/com/weirddev/testme/intellij/template/context/JavaTestBuilderImpl.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/JavaTestBuilderImpl.java
@@ -34,10 +34,6 @@ public class JavaTestBuilderImpl implements LangTestBuilder {
     private Module srcModule;
     private TypeDictionary typeDictionary;
     protected FileTemplateConfig fileTemplateConfig;
-    /**
-     *  a heuristic number, assuming too many implementations is an indicator to a general interface (i.e. comparator) - so an arbitrary implementation should not be selected in such case
-     */
-    private final int maxChildTypesForConcreteTypesSearchCandidates = 2;
 
     public JavaTestBuilderImpl(Method testedMethod, TestBuilder.ParamRole paramRole, FileTemplateConfig fileTemplateConfig, Module srcModule, TypeDictionary typeDictionary) {
         this.testedMethod = testedMethod;
@@ -156,7 +152,7 @@ public class JavaTestBuilderImpl implements LangTestBuilder {
         final PsiClass psiClass = findClassInModule(type.getCanonicalName());
         if (psiClass != null) {
             final Object[] childElements = new SubtypesHierarchyTreeStructure(srcModule.getProject(), psiClass, HierarchyBrowserBaseEx.SCOPE_PROJECT/*"All"*/).getChildElements(new TypeHierarchyNodeDescriptor(srcModule.getProject(),null,psiClass,true));
-            if (childElements != null && childElements.length > 0 && childElements.length <= maxChildTypesForConcreteTypesSearchCandidates ) {
+            if (childElements != null && childElements.length > 0 && childElements.length <= fileTemplateConfig.getMaxNumOfConcreteCandidatesToReplaceInterfaceParam()) {
                 for (Object childElement : childElements) {
                     Type childType = null;
                     if (childElement instanceof TypeHierarchyNodeDescriptor) {

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Method.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Method.java
@@ -82,7 +82,7 @@ public class Method {
         ownerClassCanonicalType = psiMethod.getContainingClass() == null ? null : psiMethod.getContainingClass().getQualifiedName();
         methodParams = extractMethodParams(typeDictionary, maxRecursionDepth,psiMethod);
         isSetter = PropertyUtil.isSimplePropertySetter(psiMethod)||PropertyUtil.isSimpleSetter(psiMethod);
-        isGetter = PropertyUtil.isSimplePropertyGetter(psiMethod)||PropertyUtil.isSimpleGetter(psiMethod);
+        isGetter = PropertyUtil.isSimplePropertyGetter(psiMethod)||PropertyUtil.isSimpleGetter(psiMethod);//todo revise ,  consider removing isSimplePropertyGetter/isSimplePropertySetter conditions
 //        final PsiField psiField = PropertyUtil.findPropertyFieldByMember(psiMethod);
 //        propertyName = psiField == null ? null : psiField.getName();
         propertyName = ClassNameUtils.extractTargetPropertyName(name,isSetter,isGetter);

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Method.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Method.java
@@ -4,7 +4,6 @@ import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.LocalSearchScope;
 import com.intellij.psi.search.searches.ReferencesSearch;
-import com.intellij.psi.util.PropertyUtil;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
 import com.weirddev.testme.intellij.resolvers.groovy.GroovyPsiTreeUtils;
@@ -13,6 +12,7 @@ import com.weirddev.testme.intellij.resolvers.to.ResolvedReference;
 import com.weirddev.testme.intellij.template.TypeDictionary;
 import com.weirddev.testme.intellij.utils.ClassNameUtils;
 import com.weirddev.testme.intellij.utils.JavaPsiTreeUtils;
+import com.weirddev.testme.intellij.utils.PropertyUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -81,8 +81,8 @@ public class Method {
         this.returnType = typeDictionary.getType(psiMethod.getReturnType(),maxRecursionDepth,true);
         ownerClassCanonicalType = psiMethod.getContainingClass() == null ? null : psiMethod.getContainingClass().getQualifiedName();
         methodParams = extractMethodParams(typeDictionary, maxRecursionDepth,psiMethod);
-        isSetter = PropertyUtil.isSimplePropertySetter(psiMethod)||PropertyUtil.isSimpleSetter(psiMethod);
-        isGetter = PropertyUtil.isSimplePropertyGetter(psiMethod)||PropertyUtil.isSimpleGetter(psiMethod);//todo revise ,  consider removing isSimplePropertyGetter/isSimplePropertySetter conditions
+        isSetter = PropertyUtils.isPropertySetter(psiMethod);
+        isGetter = PropertyUtils.isPropertyGetter(psiMethod);
 //        final PsiField psiField = PropertyUtil.findPropertyFieldByMember(psiMethod);
 //        propertyName = psiField == null ? null : psiField.getName();
         propertyName = ClassNameUtils.extractTargetPropertyName(name,isSetter,isGetter);

--- a/src/main/java/com/weirddev/testme/intellij/template/context/MockitoUtils.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/MockitoUtils.java
@@ -1,9 +1,6 @@
 package com.weirddev.testme.intellij.template.context;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Date: 31/03/2017
@@ -11,6 +8,28 @@ import java.util.Set;
  */
 
 public class  MockitoUtils {
+
+    private static final Map<String, String> TYPE_TO_ARG_MATCHERS;
+
+    static {
+        TYPE_TO_ARG_MATCHERS = new HashMap<String, String>();
+        TYPE_TO_ARG_MATCHERS.put("byte", "anyByte()");
+        TYPE_TO_ARG_MATCHERS.put("short", "anyShort()");
+        TYPE_TO_ARG_MATCHERS.put("int", "anyInt()");
+        TYPE_TO_ARG_MATCHERS.put("long", "anyLong()");
+        TYPE_TO_ARG_MATCHERS.put("float", "anyFloat()");
+        TYPE_TO_ARG_MATCHERS.put("double", "anyDouble()");
+        TYPE_TO_ARG_MATCHERS.put("char", "anyChar()");
+        TYPE_TO_ARG_MATCHERS.put("boolean", "anyBoolean()");
+        TYPE_TO_ARG_MATCHERS.put("java.lang.Byte", "anyByte()");
+        TYPE_TO_ARG_MATCHERS.put("java.lang.Short", "anyShort()");
+        TYPE_TO_ARG_MATCHERS.put("java.lang.Integer", "anyInt()");
+        TYPE_TO_ARG_MATCHERS.put("java.lang.Long", "anyLong()");
+        TYPE_TO_ARG_MATCHERS.put("java.lang.Float", "anyFloat()");
+        TYPE_TO_ARG_MATCHERS.put("java.lang.Double", "anyDouble()");
+        TYPE_TO_ARG_MATCHERS.put("java.lang.Character", "anyChar()");
+        TYPE_TO_ARG_MATCHERS.put("java.lang.Boolean", "anyBoolean()");
+    }
 
     private static final Set<String> WRAPPER_TYPES = new HashSet<String>(Arrays.asList(
             Class.class.getCanonicalName(),
@@ -57,6 +76,18 @@ public class  MockitoUtils {
             return "";
         }
     }
+    @SuppressWarnings("unused")
+    public String buildMockArgsMatchers(List<Param> params) {
+        final StringBuilder sb = new StringBuilder();
+        for (Param param : params) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            final String matcherType = TYPE_TO_ARG_MATCHERS.get(param.getType().getCanonicalName());
+            sb.append(matcherType==null?"any()":matcherType); //todo support anyCollection()?
+        }
+        return sb.toString();
+    }
     /**
         @return true - if Field should be mocked
      */
@@ -64,7 +95,7 @@ public class  MockitoUtils {
         return !field.getType().isPrimitive() && !isWrapperType(field) && !field.isStatic() && !field.isOverridden();
     }
 
-    public boolean isWrapperType(Field field) {
+    private boolean isWrapperType(Field field) {
         return WRAPPER_TYPES.contains(field.getType().getCanonicalName());
     }
 

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Reference.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Reference.java
@@ -18,8 +18,8 @@ public class Reference {
 
     public Reference(String referenceName, PsiType refType, PsiType psiOwnerType, TypeDictionary typeDictionary) {
         this.referenceName = referenceName;
-        referenceType = new Type(refType, typeDictionary, 1);
-        ownerType = new Type(psiOwnerType, typeDictionary, 1);
+        referenceType = new Type(refType, typeDictionary, 1, false);
+        ownerType = new Type(psiOwnerType, typeDictionary, 1, false);
         referenceId = ownerType.getCanonicalName() + referenceName + referenceType.getCanonicalName();
     }
 

--- a/src/main/java/com/weirddev/testme/intellij/template/context/TestBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/TestBuilder.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public interface TestBuilder {
     String renderMethodParams(Method method, Map<String, String> replacementTypes, Map<String, String> defaultTypeValues) throws Exception;
 
-    String renderReturnParam(Method method, String defaultName, Map<String, String> replacementTypes, Map<String, String> defaultTypeValues) throws Exception;
+    String renderReturnParam(Method testedMethod, Type type, String defaultName, Map<String, String> replacementTypes, Map<String, String> defaultTypeValues) throws Exception;
 
     String renderInitType(Type type, String defaultName, Map<String, String> replacementTypes, Map<String, String> defaultTypeValues) throws Exception;
     enum ParamRole {

--- a/src/main/java/com/weirddev/testme/intellij/template/context/TestBuilderImpl.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/TestBuilderImpl.java
@@ -24,8 +24,8 @@ public class TestBuilderImpl implements TestBuilder{
         return langTestBuilderFactory.createTestBuilder(method, ParamRole.Input).renderJavaCallParams(method.getMethodParams(), replacementTypes, defaultTypeValues);
     }
     @Override
-    public String renderReturnParam(Method method, String defaultName, Map<String, String> replacementTypes, Map<String, String> defaultTypeValues) throws Exception {
-        return langTestBuilderFactory.createTestBuilder(method, ParamRole.Output).renderJavaCallParam(method.getReturnType(),defaultName,replacementTypes, defaultTypeValues);
+    public String renderReturnParam(Method testedMethod, Type type, String defaultName, Map<String, String> replacementTypes, Map<String, String> defaultTypeValues) throws Exception {
+        return langTestBuilderFactory.createTestBuilder(testedMethod, ParamRole.Output).renderJavaCallParam(type,defaultName,replacementTypes, defaultTypeValues);
     }
     @Override
     public String renderInitType(Type type, String defaultName, Map<String, String> replacementTypes, Map<String, String> defaultTypeValues) throws Exception {

--- a/src/main/java/com/weirddev/testme/intellij/template/context/TestBuilderImpl.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/TestBuilderImpl.java
@@ -1,6 +1,9 @@
 package com.weirddev.testme.intellij.template.context;
 
+import com.intellij.openapi.module.Module;
+import com.weirddev.testme.intellij.template.FileTemplateConfig;
 import com.weirddev.testme.intellij.template.LangTestBuilderFactory;
+import com.weirddev.testme.intellij.template.TypeDictionary;
 
 import java.util.Map;
 
@@ -11,23 +14,21 @@ import java.util.Map;
  */
 public class TestBuilderImpl implements TestBuilder{
     private final LangTestBuilderFactory langTestBuilderFactory;
-    private final int minPercentOfExcessiveSettersToPreferDefaultCtor;
 
-    public TestBuilderImpl(Language language, int maxRecursionDepth, boolean shouldIgnoreUnusedProperties, int minPercentOfExcessiveSettersToPreferDefaultCtor) {
-        langTestBuilderFactory = new LangTestBuilderFactory(language,maxRecursionDepth, shouldIgnoreUnusedProperties);
-        this.minPercentOfExcessiveSettersToPreferDefaultCtor = minPercentOfExcessiveSettersToPreferDefaultCtor;
+    public TestBuilderImpl(Language language, Module srcModule, TypeDictionary typeDictionary, FileTemplateConfig fileTemplateConfig) {
+        langTestBuilderFactory = new LangTestBuilderFactory(language, srcModule, fileTemplateConfig,typeDictionary);
     }
 
     @Override
     public String renderMethodParams(Method method, Map<String, String> replacementTypes, Map<String, String> defaultTypeValues) throws Exception {
-        return langTestBuilderFactory.createTestBuilder(method, ParamRole.Input, minPercentOfExcessiveSettersToPreferDefaultCtor).renderJavaCallParams(method.getMethodParams(), replacementTypes, defaultTypeValues);
+        return langTestBuilderFactory.createTestBuilder(method, ParamRole.Input).renderJavaCallParams(method.getMethodParams(), replacementTypes, defaultTypeValues);
     }
     @Override
     public String renderReturnParam(Method method, String defaultName, Map<String, String> replacementTypes, Map<String, String> defaultTypeValues) throws Exception {
-        return langTestBuilderFactory.createTestBuilder(method, ParamRole.Output, minPercentOfExcessiveSettersToPreferDefaultCtor).renderJavaCallParam(method.getReturnType(),defaultName,replacementTypes, defaultTypeValues);
+        return langTestBuilderFactory.createTestBuilder(method, ParamRole.Output).renderJavaCallParam(method.getReturnType(),defaultName,replacementTypes, defaultTypeValues);
     }
     @Override
     public String renderInitType(Type type, String defaultName, Map<String, String> replacementTypes, Map<String, String> defaultTypeValues) throws Exception {
-        return langTestBuilderFactory.createTestBuilder(null,null, minPercentOfExcessiveSettersToPreferDefaultCtor).renderJavaCallParam(type,defaultName,replacementTypes, defaultTypeValues);
+        return langTestBuilderFactory.createTestBuilder(null,null).renderJavaCallParam(type,defaultName,replacementTypes, defaultTypeValues);
     }
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/context/TestMeTemplateParams.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/TestMeTemplateParams.java
@@ -16,7 +16,7 @@ public interface TestMeTemplateParams {
     String STRING_UTILS = "StringUtils";
     String MOCKITO_UTILS = "MockitoUtils";
     String TEST_SUBJECT_UTILS = "TestSubjectUtils";
-    String MAX_RECURSION_DEPTH = "MAX_RECURSION_DEPTH";
+    String MAX_RECURSION_DEPTH = "DEFAULT_MAX_RECURSION_DEPTH";
 
     String MONTH_NAME_EN = "MONTH_NAME_EN";
     String DAY_NUMERIC = "DAY_NUMERIC"; //Current Day of month for numeric calculations. i.e. if today is January the 2nd - DAY_NUMERIC = 2. DAY = 02

--- a/src/main/java/com/weirddev/testme/intellij/template/context/TestMeTemplateParams.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/TestMeTemplateParams.java
@@ -14,7 +14,7 @@ public interface TestMeTemplateParams {
 
     String TEST_BUILDER = "TestBuilder";
     String STRING_UTILS = "StringUtils";
-    String MOCKITO_UTILS = "MockitoUtils";
+    String MOCKITO_MOCK_BUILDER = "MockitoMockBuilder";
     String TEST_SUBJECT_UTILS = "TestSubjectUtils";
     String MAX_RECURSION_DEPTH = "DEFAULT_MAX_RECURSION_DEPTH";
 

--- a/src/main/java/com/weirddev/testme/intellij/template/context/TestSubjectUtils.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/TestSubjectUtils.java
@@ -21,7 +21,8 @@ public class TestSubjectUtils {
         }
         return false;
     }
-    public static boolean isMethodCalled(Method method,Set<MethodCall> methodCalls){
+    public static boolean isMethodCalled(Method method, Method byTestedMethod){
+        Set<MethodCall> methodCalls = byTestedMethod.getMethodCalls();
         boolean isMethodCalled = false;
         for (MethodCall methodCall : methodCalls) {
             if (methodCall.getMethod().getMethodId().equals(method.getMethodId())) {
@@ -29,7 +30,7 @@ public class TestSubjectUtils {
                 break;
             }
         }
-        LOG.debug("method "+method.getMethodId()+" searched in "+methodCalls.size()+" method calls - is found:"+isMethodCalled);
+        LOG.debug("method "+method.getMethodId()+" searched in "+methodCalls.size()+" method calls by tested method "+byTestedMethod.getMethodId()+" - is found:"+isMethodCalled);
         return isMethodCalled;
     }
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/context/TestSubjectUtils.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/TestSubjectUtils.java
@@ -1,5 +1,7 @@
 package com.weirddev.testme.intellij.template.context;
 
+import com.intellij.openapi.diagnostic.Logger;
+
 import java.util.List;
 import java.util.Set;
 
@@ -10,6 +12,7 @@ import java.util.Set;
  */
 @SuppressWarnings("unused")
 public class TestSubjectUtils {
+    private static final Logger LOG = Logger.getInstance(TestSubjectUtils.class.getName());
     public static boolean hasTestableInstanceMethod(List<Method> methods){
         for (Method method : methods) {
             if (method.isTestable() && !method.isStatic()) {
@@ -19,11 +22,14 @@ public class TestSubjectUtils {
         return false;
     }
     public static boolean isMethodCalled(Method method,Set<MethodCall> methodCalls){
+        boolean isMethodCalled = false;
         for (MethodCall methodCall : methodCalls) {
             if (methodCall.getMethod().getMethodId().equals(method.getMethodId())) {
-                return true;
+                isMethodCalled = true;
+                break;
             }
         }
-        return false;
+        LOG.debug("method "+method.getMethodId()+" searched in "+methodCalls.size()+" method calls - is found:"+isMethodCalled);
+        return isMethodCalled;
     }
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/context/TestSubjectUtils.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/TestSubjectUtils.java
@@ -1,6 +1,7 @@
 package com.weirddev.testme.intellij.template.context;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Date: 31/03/2017
@@ -12,6 +13,14 @@ public class TestSubjectUtils {
     public static boolean hasTestableInstanceMethod(List<Method> methods){
         for (Method method : methods) {
             if (method.isTestable() && !method.isStatic()) {
+                return true;
+            }
+        }
+        return false;
+    }
+    public static boolean isMethodCalled(Method method,Set<MethodCall> methodCalls){
+        for (MethodCall methodCall : methodCalls) {
+            if (methodCall.getMethod().getMethodId().equals(method.getMethodId())) {
                 return true;
             }
         }

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Type.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Type.java
@@ -31,7 +31,7 @@ public class Type {
     private final boolean isAbstract;
     private final boolean isStatic;
     private final boolean isFinal;
-    private final List<Method> methods;//resolve Setters/Getters only for now
+    private final List<Method> methods;
     /**
      * in case this is an inner class - the outer class where this type is defined
      */
@@ -87,18 +87,6 @@ public class Type {
         isFinal = isFinalType(psiClass);
     }
 
-    private boolean isFinalType(PsiClass aClass) {
-        return aClass != null &&  aClass.getModifierList()!=null && aClass.getModifierList().hasExplicitModifier(PsiModifier.FINAL);
-    }
-
-    private void resolveFields(@NotNull PsiClass psiClass, TypeDictionary typeDictionary, int maxRecursionDepth) {
-        for (PsiField psiField : psiClass.getAllFields()) {
-            if(!"groovy.lang.MetaClass".equals(psiField.getType().getCanonicalText())){
-                fields.add(new Field(psiField, psiClass,typeDictionary,maxRecursionDepth));
-            }
-        }
-    }
-
     @NotNull
     public static PsiClassType resolveType(PsiClass psiClass) {
         return JavaPsiFacade.getInstance(psiClass.getProject()).getElementFactory().createType(psiClass);
@@ -122,9 +110,21 @@ public class Type {
                     }
 
                 }
-            resolveFields(psiClass,typeDictionary,maxRecursionDepth);
+            resolveFields(psiClass,typeDictionary,maxRecursionDepth - 1);
             dependenciesResolved=true;
         }
+    }
+
+    private void resolveFields(@NotNull PsiClass psiClass, TypeDictionary typeDictionary, int maxRecursionDepth) {
+        for (PsiField psiField : psiClass.getAllFields()) {
+            if(!"groovy.lang.MetaClass".equals(psiField.getType().getCanonicalText())){
+                fields.add(new Field(psiField, psiClass,typeDictionary,maxRecursionDepth));
+            }
+        }
+    }
+
+    private boolean isFinalType(PsiClass aClass) {
+        return aClass != null &&  aClass.getModifierList()!=null && aClass.getModifierList().hasExplicitModifier(PsiModifier.FINAL);
     }
 
     private boolean isGroovyLangProperty(PsiMethod method) {

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Type.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Type.java
@@ -1,10 +1,10 @@
 package com.weirddev.testme.intellij.template.context;
 
 import com.intellij.psi.*;
-import com.intellij.psi.util.PropertyUtil;
 import com.intellij.psi.util.PsiUtil;
 import com.weirddev.testme.intellij.template.TypeDictionary;
 import com.weirddev.testme.intellij.utils.ClassNameUtils;
+import com.weirddev.testme.intellij.utils.PropertyUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -64,7 +64,7 @@ public class Type {
         this(ClassNameUtils.extractContainerType(canonicalName), ClassNameUtils.extractClassName(canonicalName), ClassNameUtils.extractPackageName(canonicalName),false, false,false, ClassNameUtils.isArray(canonicalName),ClassNameUtils.isVarargs(canonicalName),null);
     }
 
-    public Type(PsiType psiType, @Nullable TypeDictionary typeDictionary, int maxRecursionDepth) {
+    public Type(PsiType psiType, @Nullable TypeDictionary typeDictionary, int maxRecursionDepth, boolean shouldResolveAllMethods) {
         String canonicalText = psiType.getCanonicalText();
         array = ClassNameUtils.isArray(canonicalText);
         varargs = ClassNameUtils.isVarargs(canonicalText);
@@ -82,7 +82,7 @@ public class Type {
                 false):null;
         fields = new ArrayList<Field>();
         enumValues = resolveEnumValues(psiType);
-         dependenciesResolvable = maxRecursionDepth > 1;
+         dependenciesResolvable = shouldResolveAllMethods && maxRecursionDepth > 1;
         methods=new ArrayList<Method>();
         isFinal = isFinalType(psiClass);
     }
@@ -101,9 +101,7 @@ public class Type {
             }
             final PsiMethod[] methods = psiClass.getAllMethods();
                 for (PsiMethod psiMethod : methods) {
-                    if (Method.isRelevant(psiClass, psiMethod) &&  (shouldResolveAllMethods || (PropertyUtil.isSimplePropertySetter(psiMethod) || PropertyUtil.isSimplePropertyGetter(psiMethod)
-                            || PropertyUtil.isSimpleSetter(psiMethod)|| PropertyUtil.isSimpleGetter(psiMethod)) && !isGroovyLangProperty(psiMethod) || psiMethod.isConstructor())) {
-
+                    if (Method.isRelevant(psiClass, psiMethod) &&  (shouldResolveAllMethods || ( PropertyUtils.isPropertySetter(psiMethod) || PropertyUtils.isPropertyGetter(psiMethod)) && !isGroovyLangProperty(psiMethod) || psiMethod.isConstructor())){
                         final Method method = new Method(psiMethod, psiClass, maxRecursionDepth - 1, typeDictionary);
                         method.resolveInternalReferences(psiMethod, typeDictionary);
                         this.methods.add(method);

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Type.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Type.java
@@ -82,7 +82,7 @@ public class Type {
                 false):null;
         fields = new ArrayList<Field>();
         enumValues = resolveEnumValues(psiType);
-        dependenciesResolvable = maxRecursionDepth > 0;
+         dependenciesResolvable = maxRecursionDepth > 1;
         methods=new ArrayList<Method>();
         isFinal = isFinalType(psiClass);
     }
@@ -91,10 +91,10 @@ public class Type {
         return aClass != null &&  aClass.getModifierList()!=null && aClass.getModifierList().hasExplicitModifier(PsiModifier.FINAL);
     }
 
-    private void resolveFields(@NotNull PsiClass psiClass) {
+    private void resolveFields(@NotNull PsiClass psiClass, TypeDictionary typeDictionary, int maxRecursionDepth) {
         for (PsiField psiField : psiClass.getAllFields()) {
             if(!"groovy.lang.MetaClass".equals(psiField.getType().getCanonicalText())){
-                fields.add(new Field(psiField, psiClass));
+                fields.add(new Field(psiField, psiClass,typeDictionary,maxRecursionDepth));
             }
         }
     }
@@ -122,7 +122,7 @@ public class Type {
                     }
 
                 }
-            resolveFields(psiClass);
+            resolveFields(psiClass,typeDictionary,maxRecursionDepth);
             dependenciesResolved=true;
         }
     }

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Type.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Type.java
@@ -84,7 +84,7 @@ public class Type {
         enumValues = resolveEnumValues(psiType);
         dependenciesResolvable = maxRecursionDepth > 0;
         methods=new ArrayList<Method>();
-        isFinal = isFinalType(PsiUtil.resolveClassInType(psiType));
+        isFinal = isFinalType(psiClass);
     }
 
     private boolean isFinalType(PsiClass aClass) {

--- a/src/main/java/com/weirddev/testme/intellij/ui/TestMePopUpHandler.java
+++ b/src/main/java/com/weirddev/testme/intellij/ui/TestMePopUpHandler.java
@@ -8,6 +8,7 @@ import com.intellij.ide.util.EditSourceUtil;
 import com.intellij.ide.util.PsiElementListCellRenderer;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.navigation.NavigationItem;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.DumbService;
@@ -151,8 +152,9 @@ public abstract class TestMePopUpHandler implements CodeInsightActionHandler {
       gotoData.listUpdaterTask.init((AbstractPopup)popup, list, usageView);
       ProgressManager.getInstance().run(gotoData.listUpdaterTask);
     }
-    if(System.getProperty("testme.popoup.center", "false").equals("true")){
-       //WA for UT - swing error when popup set relative to fake test editor
+
+    if (ApplicationManager.getApplication().isHeadlessEnvironment()) {
+       //for UT support - otherwise theres a swing error when popup set relative to fake test editor
       popup.showCenteredInCurrentWindow(project);
     }else{
       popup.showInBestPositionFor(editor);

--- a/src/main/java/com/weirddev/testme/intellij/utils/Node.java
+++ b/src/main/java/com/weirddev/testme/intellij/utils/Node.java
@@ -20,6 +20,10 @@ public class Node<T> {
         return data;
     }
 
+    public Node<T> getParent() {
+        return parent;
+    }
+
     public int getDepth() {
         return depth;
     }

--- a/src/main/java/com/weirddev/testme/intellij/utils/PropertyUtils.java
+++ b/src/main/java/com/weirddev/testme/intellij/utils/PropertyUtils.java
@@ -1,0 +1,32 @@
+package com.weirddev.testme.intellij.utils;
+
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.util.PropertyUtil;
+import com.weirddev.testme.intellij.resolvers.groovy.GroovyPropertyUtil;
+import com.weirddev.testme.intellij.resolvers.groovy.GroovyPsiTreeUtils;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: yaron.yamin
+ * Date: 11/1/2017
+ * Time: 4:21 PM
+ */
+public class PropertyUtils
+{
+    public static boolean isPropertySetter(PsiMethod psiMethod) {
+        if (GroovyPsiTreeUtils.isGroovy(psiMethod.getLanguage())) {
+            return GroovyPropertyUtil.isPropertySetter(psiMethod);
+        }
+        else {
+            return PropertyUtil.isSimplePropertySetter(psiMethod) && PropertyUtil.isSimpleSetter(psiMethod);
+        }
+    }
+    public static boolean isPropertyGetter(PsiMethod psiMethod) {
+        if (GroovyPsiTreeUtils.isGroovy(psiMethod.getLanguage())) {
+            return GroovyPropertyUtil.isPropertyGetter(psiMethod);
+        }
+        else {
+            return PropertyUtil.isSimplePropertyGetter(psiMethod) && PropertyUtil.isSimpleGetter(psiMethod);
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>com.weirddev.testme</id>
   <name>TestMe</name>
-  <version>1.6</version>
+  <version>1.7</version>
   <vendor email="testme@weirddev.com" url="http://weirddev.com">WeirdDev</vendor>
 
   <description><![CDATA[
@@ -18,13 +18,11 @@
     ]]></description>
 
   <change-notes><![CDATA[
-        <i>Main Changes in v1.6:</i>
+        <i>Main Changes in v1.7:</i>
           <ul>
-            <li>Test params generator improvements: heuristically identify and ignore unused properties by the tested method, pass null for constructor arguments that initialize unused properties</li>
-            <li>Mock final classes when Mockito option <i>mock-maker-inline</i> is set in project resource file <i>/mockito-extensions/org.mockito.plugins.MockMaker</i> (reported by koperko on Aug 11 '17)</li>
-            <li>bugfix: Goto Test or Test Generation popup doesn't open for python files due to internal error on testability validation check (reported by aristotll on July 30 '17)</li>
-            <li>bugfix: test params generator - Java Primitive wrappers should not be unwrapped to avoid method call ambiguity (reported by intars on June 6 '17)</li>
-            <li>bugfix: auto location of the appropriate target test module src directory in a multi module project</li>
+            <li>Generate mocked return values for method calls of mocked dependencies in tested class</li>
+            <li>Test params generator: locate and initialize concrete types found in project source instead of passing null for interface/abstract parameter types</li>
+            <li>Get configuration from system properties (a temporary solution to support runtime configuration control via the built in IDE Scripting Console - on the Tools menu). Note: Some of these configuration properties may not be supported in future releases. <a href="http://weirddev.com/blog/testme/testme-configuration-hacks">More info and usage instructions here</a></li>
           </ul>
         <a href="http://weirddev.com/testme/release-notes">Complete Changelog</a>
     ]]>

--- a/src/main/resources/fileTemplates/internal/TestMe with Groovy, JUnit4 & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with Groovy, JUnit4 & Mockito.groovy.ft
@@ -31,6 +31,7 @@ class ${CLASS_NAME} {
     void #renderTestMethodName($method.name)() {
 #if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
 #grRenderMockStubs($method,$TESTED_CLASS.fields)
+
 #end
         #grRenderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        assert #grRenderAssert($method)#end

--- a/src/main/resources/fileTemplates/internal/TestMe with Groovy, JUnit4 & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with Groovy, JUnit4 & Mockito.groovy.ft
@@ -29,6 +29,7 @@ class ${CLASS_NAME} {
 
     @Test
     void #renderTestMethodName($method.name)() {
+        #grRenderMockedReturnedValues($method,$TESTED_CLASS.fields)
         #grRenderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        assert #grRenderAssert($method)#end
     }

--- a/src/main/resources/fileTemplates/internal/TestMe with Groovy, JUnit4 & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with Groovy, JUnit4 & Mockito.groovy.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.groovy")
-#set($hasMocks=$MockitoUtils.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME}
 #end
@@ -29,7 +29,9 @@ class ${CLASS_NAME} {
 
     @Test
     void #renderTestMethodName($method.name)() {
-        #grRenderMockedReturnedValues($method,$TESTED_CLASS.fields)
+#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+#grRenderMockStubs($method,$TESTED_CLASS.fields)
+#end
         #grRenderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        assert #grRenderAssert($method)#end
     }

--- a/src/main/resources/fileTemplates/internal/TestMe with Groovy, Spock & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with Groovy, Spock & Mockito.groovy.ft
@@ -26,6 +26,7 @@ class ${CLASS_NAME}  extends Specification {
 
     def "#renderTestMethodNameAsWords($method.name)"() {
         when:
+        #grRenderMockedReturnedValues($method,$TESTED_CLASS.fields)
         #grRenderMethodCall($method,$TESTED_CLASS.name)
 
         then:

--- a/src/main/resources/fileTemplates/internal/TestMe with Groovy, Spock & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with Groovy, Spock & Mockito.groovy.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.groovy")
-#set($hasMocks=$MockitoUtils.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME}
 #end
@@ -25,8 +25,12 @@ class ${CLASS_NAME}  extends Specification {
 #if($method.isTestable())
 
     def "#renderTestMethodNameAsWords($method.name)"() {
+#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+        given:
+#grRenderMockStubs($method,$TESTED_CLASS.fields)
+
+#end
         when:
-        #grRenderMockedReturnedValues($method,$TESTED_CLASS.fields)
         #grRenderMethodCall($method,$TESTED_CLASS.name)
 
         then:

--- a/src/main/resources/fileTemplates/internal/TestMe with JUnit4 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with JUnit4 & Mockito.java.ft
@@ -32,6 +32,7 @@ public class ${CLASS_NAME} {
     public void #renderTestMethodName($method.name)() throws Exception {
 #if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
 #renderMockStubs($method,$TESTED_CLASS.fields)
+
 #end
         #renderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        Assert.#renderJUnitAssert($method)#end

--- a/src/main/resources/fileTemplates/internal/TestMe with JUnit4 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with JUnit4 & Mockito.java.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.java")
-#set($hasMocks=$MockitoUtils.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME};
 #end
@@ -30,7 +30,9 @@ public class ${CLASS_NAME} {
 
     @Test
     public void #renderTestMethodName($method.name)() throws Exception {
-        #renderMockedReturnedValues($method,$TESTED_CLASS.fields)
+#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+#renderMockStubs($method,$TESTED_CLASS.fields)
+#end
         #renderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        Assert.#renderJUnitAssert($method)#end
     }

--- a/src/main/resources/fileTemplates/internal/TestMe with JUnit4 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with JUnit4 & Mockito.java.ft
@@ -30,6 +30,7 @@ public class ${CLASS_NAME} {
 
     @Test
     public void #renderTestMethodName($method.name)() throws Exception {
+        #renderMockedReturnedValues($method,$TESTED_CLASS.fields)
         #renderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        Assert.#renderJUnitAssert($method)#end
     }

--- a/src/main/resources/fileTemplates/internal/TestMe with JUnit5 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with JUnit5 & Mockito.java.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.java")
-#set($hasMocks=$MockitoUtils.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME};
 #end
@@ -29,6 +29,9 @@ class ${CLASS_NAME} {
 
     @Test
     void #renderTestMethodName($method.name)(){
+#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+#renderMockStubs($method,$TESTED_CLASS.fields)
+#end
         #renderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        Assertions.#renderJUnitAssert($method)#end
     }

--- a/src/main/resources/fileTemplates/internal/TestMe with JUnit5 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with JUnit5 & Mockito.java.ft
@@ -31,6 +31,7 @@ class ${CLASS_NAME} {
     void #renderTestMethodName($method.name)(){
 #if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
 #renderMockStubs($method,$TESTED_CLASS.fields)
+
 #end
         #renderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        Assertions.#renderJUnitAssert($method)#end

--- a/src/main/resources/fileTemplates/internal/TestMe with TestNG & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with TestNG & Mockito.java.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.java")
-#set($hasMocks=$MockitoUtils.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME};
 #end
@@ -29,7 +29,9 @@ public class ${CLASS_NAME} {
 
     @Test
     public void #renderTestMethodName($method.name)(){
-        #renderMockedReturnedValues($method,$TESTED_CLASS.fields)
+#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+#renderMockStubs($method,$TESTED_CLASS.fields)
+#end
         #renderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        Assert.#renderTestNgAssert($method)#end
     }

--- a/src/main/resources/fileTemplates/internal/TestMe with TestNG & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with TestNG & Mockito.java.ft
@@ -29,6 +29,7 @@ public class ${CLASS_NAME} {
 
     @Test
     public void #renderTestMethodName($method.name)(){
+        #renderMockedReturnedValues($method,$TESTED_CLASS.fields)
         #renderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        Assert.#renderTestNgAssert($method)#end
     }

--- a/src/main/resources/fileTemplates/internal/TestMe with TestNG & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/internal/TestMe with TestNG & Mockito.java.ft
@@ -31,6 +31,7 @@ public class ${CLASS_NAME} {
     public void #renderTestMethodName($method.name)(){
 #if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
 #renderMockStubs($method,$TESTED_CLASS.fields)
+
 #end
         #renderMethodCall($method,$TESTED_CLASS.name)
 #if($method.returnType && $method.returnType.name !="void")        Assert.#renderTestNgAssert($method)#end

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
@@ -83,7 +83,7 @@ result == $TestBuilder.renderReturnParam($method,$method.returnType,"replaceMeWi
 #foreach($field in $testedClassFields)
 #if($MockitoMockBuilder.isMockable($field))
 #foreach($fieldMethod in $field.type.methods)
-#if($fieldMethod.returnType && $fieldMethod.returnType.name !="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method.methodCalls))
+#if($fieldMethod.returnType && $fieldMethod.returnType.name !="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
         when($field.name.${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams}))).thenReturn($TestBuilder.renderReturnParam($method,$fieldMethod.returnType,"${fieldMethod.name}Response",$grReplacementTypes,$grDefaultTypeValues))
 #end
 #end

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
@@ -72,10 +72,22 @@
 #end
 ##
 #macro(grRenderAssert $method)
-result == $TestBuilder.renderReturnParam($method,"replaceMeWithExpectedResult",$grReplacementTypes,$grDefaultTypeValues)
+result == $TestBuilder.renderReturnParam($method,$method.returnType,"replaceMeWithExpectedResult",$grReplacementTypes,$grDefaultTypeValues)
 #end
 ##
 #macro(grRenderMethodCall $method,$testedClassName)
 #renderJavaReturnVar($method.returnType)#if($method.static)$testedClassName#{else}$StringUtils.deCapitalizeFirstLetter($testedClassName)#end.${method.name}($TestBuilder.renderMethodParams($method,$grReplacementTypes,$grDefaultTypeValues))
+#end
+##
+#macro(grRenderMockedReturnedValues $method $testedClassFields)
+#foreach($field in $testedClassFields)
+#if($MockitoUtils.isMockable($field))
+#foreach($fieldMethod in $field.type.methods)
+#if($fieldMethod.returnType && $TestSubjectUtils.isMethodCalled($fieldMethod,$method.methodCalls))
+    when($field.name.${fieldMethod.name}($MockitoUtils.buildMockArgsMatchers(${fieldMethod.methodParams}))).thenReturn($TestBuilder.renderReturnParam($method,$fieldMethod.returnType,"${fieldMethod.name}Response",$grReplacementTypes,$grDefaultTypeValues))
+#end##
+#end
+#end
+#end
 #end
 ##

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
@@ -62,11 +62,11 @@
 ##
 #macro(grRenderMockedFields $testedClassFields)
 #foreach($field in $testedClassFields)
-#if($MockitoUtils.isMockable($field))
+#if($MockitoMockBuilder.isMockable($field))
     @Mock
     $field.type.canonicalName $field.name
-#elseif($MockitoUtils.isMockExpected($field))
-    $MockitoUtils.getImmockabiliyReason("//",$field)
+#elseif($MockitoMockBuilder.isMockExpected($field))
+    $MockitoMockBuilder.getImmockabiliyReason("//",$field)
 #end
 #end
 #end
@@ -79,15 +79,14 @@ result == $TestBuilder.renderReturnParam($method,$method.returnType,"replaceMeWi
 #renderJavaReturnVar($method.returnType)#if($method.static)$testedClassName#{else}$StringUtils.deCapitalizeFirstLetter($testedClassName)#end.${method.name}($TestBuilder.renderMethodParams($method,$grReplacementTypes,$grDefaultTypeValues))
 #end
 ##
-#macro(grRenderMockedReturnedValues $method $testedClassFields)
+#macro(grRenderMockStubs $method $testedClassFields)
 #foreach($field in $testedClassFields)
-#if($MockitoUtils.isMockable($field))
+#if($MockitoMockBuilder.isMockable($field))
 #foreach($fieldMethod in $field.type.methods)
-#if($fieldMethod.returnType && $TestSubjectUtils.isMethodCalled($fieldMethod,$method.methodCalls))
-    when($field.name.${fieldMethod.name}($MockitoUtils.buildMockArgsMatchers(${fieldMethod.methodParams}))).thenReturn($TestBuilder.renderReturnParam($method,$fieldMethod.returnType,"${fieldMethod.name}Response",$grReplacementTypes,$grDefaultTypeValues))
-#end##
+#if($fieldMethod.returnType && $fieldMethod.returnType.name !="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method.methodCalls))
+        when($field.name.${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams}))).thenReturn($TestBuilder.renderReturnParam($method,$fieldMethod.returnType,"${fieldMethod.name}Response",$grReplacementTypes,$grDefaultTypeValues))
 #end
 #end
 #end
 #end
-##
+#end

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
@@ -74,11 +74,11 @@
 #end
 ##
 #macro(renderJUnitAssert $method)
-#renderJunitAssertMethod($method.returnType)($TestBuilder.renderReturnParam($method,"replaceMeWithExpectedResult",$replacementTypes,$defaultTypeValues), result);
+#renderJunitAssertMethod($method.returnType)($TestBuilder.renderReturnParam($method,$method.returnType,"replaceMeWithExpectedResult",$replacementTypes,$defaultTypeValues), result);
 #end
 ##
 #macro(renderTestNgAssert $method)
-assertEquals(result, $TestBuilder.renderReturnParam($method,"replaceMeWithExpectedResult",$replacementTypes,$defaultTypeValues));
+assertEquals(result, $TestBuilder.renderReturnParam($method,$method.returnType,"replaceMeWithExpectedResult",$replacementTypes,$defaultTypeValues));
 #end
 ##
 #macro(renderJunitAssertMethod $type)
@@ -88,3 +88,16 @@ assertEquals(result, $TestBuilder.renderReturnParam($method,"replaceMeWithExpect
 #macro(renderMethodCall $method,$testedClassName)
 #renderJavaReturnVar($method.returnType)#if($method.static)$testedClassName#{else}$StringUtils.deCapitalizeFirstLetter($testedClassName)#end.${method.name}($TestBuilder.renderMethodParams($method,$replacementTypes,$defaultTypeValues));
 #end
+##
+#macro(renderMockedReturnedValues $method $testedClassFields)
+#foreach($field in $testedClassFields)
+#if($MockitoUtils.isMockable($field))
+#foreach($fieldMethod in $field.type.methods)
+#if($fieldMethod.returnType && $TestSubjectUtils.isMethodCalled($fieldMethod,$method.methodCalls))
+    when($field.name.${fieldMethod.name}($MockitoUtils.buildMockArgsMatchers(${fieldMethod.methodParams}))).thenReturn($TestBuilder.renderReturnParam($method,$fieldMethod.returnType,"${fieldMethod.name}Response",$replacementTypes,$defaultTypeValues));
+#end##
+#end
+#end
+#end
+#end
+##

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
@@ -93,7 +93,7 @@ assertEquals(result, $TestBuilder.renderReturnParam($method,$method.returnType,"
 #foreach($field in $testedClassFields)
 #if($MockitoMockBuilder.isMockable($field))
 #foreach($fieldMethod in $field.type.methods)
-#if($fieldMethod.returnType && $fieldMethod.returnType.name !="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method.methodCalls))
+#if($fieldMethod.returnType && $fieldMethod.returnType.name !="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
         when($field.name.${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams}))).thenReturn($TestBuilder.renderReturnParam($method,$fieldMethod.returnType,"${fieldMethod.name}Response",$replacementTypes,$defaultTypeValues));
 #end
 #end

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
@@ -60,11 +60,11 @@
 ##
 #macro(renderMockedFields $testedClassFields)
 #foreach($field in $testedClassFields)
-#if($MockitoUtils.isMockable($field))
+#if($MockitoMockBuilder.isMockable($field))
     @Mock
     $field.type.canonicalName $field.name;
-#elseif($MockitoUtils.isMockExpected($field))
-    $MockitoUtils.getImmockabiliyReason("//",$field)
+#elseif($MockitoMockBuilder.isMockExpected($field))
+    $MockitoMockBuilder.getImmockabiliyReason("//",$field)
 #end
 #end
 #end
@@ -89,15 +89,14 @@ assertEquals(result, $TestBuilder.renderReturnParam($method,$method.returnType,"
 #renderJavaReturnVar($method.returnType)#if($method.static)$testedClassName#{else}$StringUtils.deCapitalizeFirstLetter($testedClassName)#end.${method.name}($TestBuilder.renderMethodParams($method,$replacementTypes,$defaultTypeValues));
 #end
 ##
-#macro(renderMockedReturnedValues $method $testedClassFields)
+#macro(renderMockStubs $method $testedClassFields)
 #foreach($field in $testedClassFields)
-#if($MockitoUtils.isMockable($field))
+#if($MockitoMockBuilder.isMockable($field))
 #foreach($fieldMethod in $field.type.methods)
-#if($fieldMethod.returnType && $TestSubjectUtils.isMethodCalled($fieldMethod,$method.methodCalls))
-    when($field.name.${fieldMethod.name}($MockitoUtils.buildMockArgsMatchers(${fieldMethod.methodParams}))).thenReturn($TestBuilder.renderReturnParam($method,$fieldMethod.returnType,"${fieldMethod.name}Response",$replacementTypes,$defaultTypeValues));
-#end##
+#if($fieldMethod.returnType && $fieldMethod.returnType.name !="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method.methodCalls))
+        when($field.name.${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams}))).thenReturn($TestBuilder.renderReturnParam($method,$fieldMethod.returnType,"${fieldMethod.name}Response",$replacementTypes,$defaultTypeValues));
 #end
 #end
 #end
 #end
-##
+#end

--- a/src/test/groovy/com/weirddev/testme/intellij/template/context/GroovyTestBuilderImplTest.groovy
+++ b/src/test/groovy/com/weirddev/testme/intellij/template/context/GroovyTestBuilderImplTest.groovy
@@ -1,5 +1,6 @@
 package com.weirddev.testme.intellij.template.context
 
+import com.weirddev.testme.intellij.template.FileTemplateConfig
 import spock.lang.Specification
 
 /**
@@ -10,7 +11,7 @@ class GroovyTestBuilderImplTest extends Specification {
 
     def "test should Prefer Setters Over Ctor"() {
         given:
-        GroovyTestBuilderImpl groovyTestBuilderImpl = new GroovyTestBuilderImpl(4, null, true, null, 50, 66)
+        GroovyTestBuilderImpl groovyTestBuilderImpl = new GroovyTestBuilderImpl(null, null, new FileTemplateConfig(), null, null)
 
         expect:
         result == groovyTestBuilderImpl.shouldPreferSettersOverCtor(noOfCtorArgs, noOfSetters)
@@ -34,7 +35,7 @@ class GroovyTestBuilderImplTest extends Specification {
 
     def "test should Optimize Constructor Optimization"() {
         given:
-        GroovyTestBuilderImpl groovyTestBuilderImpl = new GroovyTestBuilderImpl(4, null, true, null, 50, 66)
+        GroovyTestBuilderImpl groovyTestBuilderImpl = new GroovyTestBuilderImpl(null, null, new FileTemplateConfig(minPercentOfExcessiveSettersToPreferMapCtor: 50,minPercentOfInteractionWithPropertiesToTriggerConstructorOptimization: 66,maxRecursionDepth: 4), null, null)
 
         expect:
         result == groovyTestBuilderImpl.shouldOptimizeConstructorInitialization(nTotalTypeUsages, nBeanUsages)

--- a/src/test/groovy/com/weirddev/testme/intellij/template/context/GroovyTestBuilderImplTest.groovy
+++ b/src/test/groovy/com/weirddev/testme/intellij/template/context/GroovyTestBuilderImplTest.groovy
@@ -11,7 +11,7 @@ class GroovyTestBuilderImplTest extends Specification {
 
     def "test should Prefer Setters Over Ctor"() {
         given:
-        GroovyTestBuilderImpl groovyTestBuilderImpl = new GroovyTestBuilderImpl(null, null, new FileTemplateConfig(), null, null)
+        GroovyTestBuilderImpl groovyTestBuilderImpl = new GroovyTestBuilderImpl(null, null, FileTemplateConfig.getInstance(), null, null)
 
         expect:
         result == groovyTestBuilderImpl.shouldPreferSettersOverCtor(noOfCtorArgs, noOfSetters)

--- a/src/test/groovy/com/weirddev/testme/intellij/template/context/JavaTestBuilderImplTest.groovy
+++ b/src/test/groovy/com/weirddev/testme/intellij/template/context/JavaTestBuilderImplTest.groovy
@@ -1,5 +1,6 @@
 package com.weirddev.testme.intellij.template.context
 
+import com.weirddev.testme.intellij.template.FileTemplateConfig
 import com.weirddev.testme.intellij.utils.ClassNameUtils
 import spock.lang.Specification
 
@@ -17,7 +18,7 @@ class JavaTestBuilderImplTest extends Specification {
                                        "java.util.NavigableMap": "new java.util.TreeMap<TYPES>(new java.util.HashMap<TYPES>(){{put(<VAL>,<VAL>);}})",
                                        "java.util.List"        : "java.util.Arrays.<TYPES>asList(<VAL>)"
     ]
-    def testBuilder = new JavaTestBuilderImpl(5,null,false,TestBuilder.ParamRole.Input,66)
+    def testBuilder = new JavaTestBuilderImpl(null, TestBuilder.ParamRole.Input, new FileTemplateConfig(), null, null)
 
     def "stripGenerics"() {
 
@@ -45,7 +46,7 @@ class JavaTestBuilderImplTest extends Specification {
 
     def "resolveType"() {
         expect:
-        result == testBuilder.resolveType(new Type(canonicalName, "Set", "java.util", false, false, false, false, false, []), replacementMap as HashMap)
+        result == testBuilder.resolveTypeName(new Type(canonicalName, "Set", "java.util", false, false, false, false, false, []), replacementMap as HashMap)
 
         where:
         result                          | canonicalName               | replacementMap

--- a/src/test/groovy/com/weirddev/testme/intellij/template/context/JavaTestBuilderImplTest.groovy
+++ b/src/test/groovy/com/weirddev/testme/intellij/template/context/JavaTestBuilderImplTest.groovy
@@ -18,7 +18,7 @@ class JavaTestBuilderImplTest extends Specification {
                                        "java.util.NavigableMap": "new java.util.TreeMap<TYPES>(new java.util.HashMap<TYPES>(){{put(<VAL>,<VAL>);}})",
                                        "java.util.List"        : "java.util.Arrays.<TYPES>asList(<VAL>)"
     ]
-    def testBuilder = new JavaTestBuilderImpl(null, TestBuilder.ParamRole.Input, new FileTemplateConfig(), null, null)
+    def testBuilder = new JavaTestBuilderImpl(null, TestBuilder.ParamRole.Input, FileTemplateConfig.getInstance(), null, null)
 
     def "stripGenerics"() {
 

--- a/testData/commonSrc/com/example/SelfReferringType.java
+++ b/testData/commonSrc/com/example/SelfReferringType.java
@@ -1,0 +1,20 @@
+package com.example;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Created by Admin on 10/31/2017.
+ */
+
+public enum SelfReferringType {
+    ONE,
+    TWO,
+    THREE;
+
+    private static List<SelfReferringType> firstTwo = Arrays.asList(ONE,TWO);
+
+    public List<SelfReferringType> getFirstTwo() {
+        return firstTwo;
+    }
+}

--- a/testData/commonSrc/com/example/dependencies/Logger.java
+++ b/testData/commonSrc/com/example/dependencies/Logger.java
@@ -1,0 +1,8 @@
+package com.example.dependencies;
+
+/**
+ * Created by Admin on 10/31/2017.
+ */
+public interface Logger {
+    public void trace(String msg);
+}

--- a/testData/commonSrc/com/example/dependencies/SelfishService.java
+++ b/testData/commonSrc/com/example/dependencies/SelfishService.java
@@ -1,0 +1,11 @@
+package com.example.dependencies;
+
+import com.example.SelfReferringType;
+
+/**
+ * Created by Admin on 10/31/2017.
+ */
+public interface SelfishService {
+    SelfReferringType getSelfishType();
+
+}

--- a/testData/commonSrc/com/example/foes/BeanDependsOnInterface.java
+++ b/testData/commonSrc/com/example/foes/BeanDependsOnInterface.java
@@ -12,7 +12,6 @@ public class BeanDependsOnInterface {
         this.master = master;
     }
 
-    @Override
     public String BeanDependsOnInterface() {
         return "BeanDependsOnInterface{" +
                 "master=" + master +

--- a/testData/commonSrc/com/example/foes/Fear.java
+++ b/testData/commonSrc/com/example/foes/Fear.java
@@ -11,4 +11,9 @@ public class Fear implements Comparable{
     public boolean equals(Object obj) {
         return true;
     }
+
+    @Override
+    public String toString() {
+        return "Fear{}";
+    }
 }

--- a/testData/commonSrc/com/example/services/impl/DelegateCtor.java
+++ b/testData/commonSrc/com/example/services/impl/DelegateCtor.java
@@ -9,7 +9,6 @@ public class DelegateCtor {
     private Fire youreWilling;
     private String asCold;
     private Ice asIce;
-    private youreWilling Fire;
 
     protected DelegateCtor(String youre,String asCold,Ice asIce, Fire youreWilling ){
         this(asCold, asIce);

--- a/testData/commonSrc/com/example/services/impl/DoneThat.java
+++ b/testData/commonSrc/com/example/services/impl/DoneThat.java
@@ -14,9 +14,9 @@ public class DoneThat {
     private final Many time;
     private final Date now;
     private final BigBean bean;
-    private final String privateProperty;
-    private final String bewareOfTheDog;
-    private final String ifYourInDaHood;
+    private String privateProperty;
+    private String bewareOfTheDog;
+    private String ifYourInDaHood;
 
     public DoneThat(int severalTimes, String aDay, Many time, Date now, BigBean bean) {
         this.severalTimes = severalTimes;

--- a/testData/commonSrc/com/example/services/impl/FooBro.groovy
+++ b/testData/commonSrc/com/example/services/impl/FooBro.groovy
@@ -6,6 +6,7 @@ package com.example.services.impl
 class FooBro {
     String propInSamePackage
     int iCanBeAccessedDirectly
+    int antoherDirectlyAccessedInt
     Date anotherProp
 
     Date getAnotherProp() {
@@ -14,13 +15,5 @@ class FooBro {
 
     void setAnotherProp(Date anotherProp) {
         this.anotherProp = anotherProp
-    }
-
-    String getPropInSamePackage() {
-        return propInSamePackage
-    }
-
-    void setPropInSamePackage(String propInSamePackage) {
-        this.propInSamePackage = propInSamePackage
     }
 }

--- a/testData/commonSrc/com/example/warriers/FooFighter.java
+++ b/testData/commonSrc/com/example/warriers/FooFighter.java
@@ -1,8 +1,12 @@
 package com.example.warriers;
 
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fear;
 import com.example.foes.Fire;
+import com.example.foes.Ice;
 
 /** Test input class*/
 public interface FooFighter {
     String fight(Fire withFire);
+    ConvertedBean surrender(Fear fear, Ice ice,int times);
 }

--- a/testData/commonSrc/com/example/warriers/impl/FooFighterImpl.java
+++ b/testData/commonSrc/com/example/warriers/impl/FooFighterImpl.java
@@ -1,12 +1,22 @@
 package com.example.warriers.impl;
 
-import com.example.warriers.FooFighter;
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fear;
 import com.example.foes.Fire;
+import com.example.foes.Ice;
+import com.example.warriers.FooFighter;
 
 /** Test input class*/
 public class FooFighterImpl implements FooFighter {
     @Override
     public String fight(Fire withFire) {
         return "flames";
+    }
+
+    @Override
+    public ConvertedBean surrender(Fear fear, Ice ice,int times) {
+        System.out.println("times:" + times);
+        System.out.println("fear:" + fear.toString());
+        return new ConvertedBean();
     }
 }

--- a/testData/testMeAdditionalAction/innerStaticClassWithMember/test/com/example/services/impl/InnerStaticClassWithMemberTest.java
+++ b/testData/testMeAdditionalAction/innerStaticClassWithMember/test/com/example/services/impl/InnerStaticClassWithMemberTest.java
@@ -27,6 +27,8 @@ public class InnerStaticClassWithMemberTest {
 
     @Test
     public void testMethodOfInnerClass() throws Exception {
+        when(innerFooFighter.fight(any())).thenReturn("fightResponse");
+
         String result = innerStaticClassWithMember.methodOfInnerClass(new Fire());
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }

--- a/testData/testMeGenerator/avoidInfiniteRecursionSelfReferences/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/avoidInfiniteRecursionSelfReferences/src/com/example/services/impl/Foo.java
@@ -1,0 +1,21 @@
+package com.example.services.impl;
+
+import com.example.dependencies.SelfishService;
+
+/**
+ * Testing dependency containing reference to a type that has internal references to himself. motivation: verify there's no infinite recursion issues
+ */
+public class Foo{
+
+    private SelfishService selfishService;
+
+    /**
+     * verify tested method is generated for this - method is not mistakenly identified as a getter
+     */
+    public String getSelf() {
+        return selfishService.getSelfishType().toString();
+    }
+    public String doSelf() {
+        return selfishService.getSelfishType().toString();
+    }
+}

--- a/testData/testMeGenerator/avoidInfiniteRecursionSelfReferences/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/avoidInfiniteRecursionSelfReferences/test/com/example/services/impl/FooTest.java
@@ -26,15 +26,17 @@ public class FooTest {
     }
 
     @Test
-    public void testDoSelf() throws Exception {
+    public void testGetSelf() throws Exception {
         when(selfishService.getSelfishType()).thenReturn(SelfReferringType.ONE);
-        String result = foo.doSelf();
+
+        String result = foo.getSelf();
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }
 
     @Test
-    public void testGetSelf() throws Exception {
+    public void testDoSelf() throws Exception {
         when(selfishService.getSelfishType()).thenReturn(SelfReferringType.ONE);
+
         String result = foo.doSelf();
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }

--- a/testData/testMeGenerator/avoidInfiniteRecursionSelfReferences/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/avoidInfiniteRecursionSelfReferences/test/com/example/services/impl/FooTest.java
@@ -1,9 +1,7 @@
 package com.example.services.impl;
 
-import com.example.beans.ConvertedBean;
-import com.example.dependencies.Logger;
-import com.example.foes.Fire;
-import com.example.warriers.FooFighter;
+import com.example.SelfReferringType;
+import com.example.dependencies.SelfishService;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,9 +16,7 @@ import static org.mockito.Mockito.*;
  */
 public class FooTest {
     @Mock
-    FooFighter fooFighter;
-    @Mock
-    Logger logger;
+    SelfishService selfishService;
     @InjectMocks
     Foo foo;
 
@@ -30,9 +26,16 @@ public class FooTest {
     }
 
     @Test
-    public void testFight() throws Exception {
-        when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
-        String result = foo.fight(new Fire(), "foeName");
+    public void testDoSelf() throws Exception {
+        when(selfishService.getSelfishType()).thenReturn(SelfReferringType.ONE);
+        String result = foo.doSelf();
+        Assert.assertEquals("replaceMeWithExpectedResult", result);
+    }
+
+    @Test
+    public void testGetSelf() throws Exception {
+        when(selfishService.getSelfishType()).thenReturn(SelfReferringType.ONE);
+        String result = foo.doSelf();
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }
 }

--- a/testData/testMeGenerator/avoidInfiniteRecursionSelfReferences/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/avoidInfiniteRecursionSelfReferences/testGroovy/com/example/services/impl/FooTest.groovy
@@ -1,5 +1,7 @@
 package com.example.services.impl
 
+import com.example.SelfReferringType
+import com.example.dependencies.SelfishService
 import org.junit.Test
 import org.junit.Before
 import org.mockito.InjectMocks
@@ -10,11 +12,9 @@ import static org.mockito.Mockito.*
 /** created by TestMe integration test on MMXVI */
 class FooTest {
     @Mock
-    com.example.warriers.FooFighter fooFighter
-    @Mock
-    com.example.foes.Pokemon pokey
+    SelfishService selfishService
     @InjectMocks
-    com.example.services.impl.Foo foo
+    Foo foo
 
     @Before
     void setUp() {
@@ -22,20 +22,16 @@ class FooTest {
     }
 
     @Test
-    void testFight() {
-        when(fooFighter.fight(any())).thenReturn("fightResponse")
-        java.lang.String result = foo.fight(new com.example.foes.Fire(), "foeName")
+    void testDoSelf() {
+        when(selfishService.getSelfishType()).thenReturn(SelfReferringType.ONE)
+        String result = foo.doSelf()
         assert result == "replaceMeWithExpectedResult"
     }
 
     @Test
-    void testIDefault() {
-        foo.iDefault()
-    }
-
-    @Test
-    void testAsFather() {
-        java.lang.String result = foo.asFather("asSon")
+    void testGet() {
+        when(selfishService.getSelfishType()).thenReturn(SelfReferringType.ONE)
+        String result = foo.doSelf()
         assert result == "replaceMeWithExpectedResult"
     }
 }

--- a/testData/testMeGenerator/avoidInfiniteRecursionSelfReferences/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/avoidInfiniteRecursionSelfReferences/testGroovy/com/example/services/impl/FooTest.groovy
@@ -22,15 +22,17 @@ class FooTest {
     }
 
     @Test
-    void testDoSelf() {
+    void testGetSelf() {
         when(selfishService.getSelfishType()).thenReturn(SelfReferringType.ONE)
-        String result = foo.doSelf()
+
+        String result = foo.getSelf()
         assert result == "replaceMeWithExpectedResult"
     }
 
     @Test
-    void testGet() {
+    void testDoSelf() {
         when(selfishService.getSelfishType()).thenReturn(SelfReferringType.ONE)
+
         String result = foo.doSelf()
         assert result == "replaceMeWithExpectedResult"
     }

--- a/testData/testMeGenerator/ignoreUnusedPropertiesInGroovy/src/com/example/services/impl/Foo.groovy
+++ b/testData/testMeGenerator/ignoreUnusedPropertiesInGroovy/src/com/example/services/impl/Foo.groovy
@@ -13,7 +13,8 @@ class Foo {
     Collection<JavaBean> myBeans
 
     String smashing(FooBro fooBro,JavaBean javaBean){
-        println fooBro.iCanBeAccessedDirectly
+//        println fooBro.iCanBeAccessedDirectly //todo - problematic use case, when uncommented, iCanBeAccessedDirectly property should be set in map constructor of generated groovy test, but property access is not identified , probably because groovy compiler generated getiCanBeAccessedDirectly() instead of getICanBeAccessedDirectly()
+        println fooBro.antoherDirectlyAccessedInt
         callMe(fooBro, javaBean)
         javaBean   .   getFire()
         return javaBean  /*comment should be ignored */  .   ice  .  toString()

--- a/testData/testMeGenerator/ignoreUnusedPropertiesInGroovy/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/ignoreUnusedPropertiesInGroovy/testGroovy/com/example/services/impl/FooTest.groovy
@@ -28,7 +28,7 @@ class FooTest {
 
     @Test
     void testSmashing() {
-        String result = foo.smashing(new FooBro(propInSamePackage: "propInSamePackage", iCanBeAccessedDirectly: 0), new JavaBean(fear: new Fear(), fire: new Fire(), ice: new Ice()))
+        String result = foo.smashing(new FooBro(propInSamePackage: "propInSamePackage", antoherDirectlyAccessedInt: 0), new JavaBean(fear: new Fear(), fire: new Fire(), ice: new Ice()))
         assert result == "replaceMeWithExpectedResult"
     }
 

--- a/testData/testMeGenerator/inheritance/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/inheritance/test/com/example/services/impl/FooTest.java
@@ -9,9 +9,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.mockito.Mockito.*;
 
-/**
- * created by TestMe integration test on MMXVI
- */
+/** created by TestMe integration test on MMXVI */
 public class FooTest {
     @Mock
     com.example.warriers.FooFighter fooFighter;
@@ -27,6 +25,7 @@ public class FooTest {
 
     @Test
     public void testFight() throws Exception {
+        when(fooFighter.fight(any())).thenReturn("fightResponse");
         String result = foo.fight(new com.example.foes.Fire(), "foeName");
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }

--- a/testData/testMeGenerator/inheritance/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/inheritance/test/com/example/services/impl/FooTest.java
@@ -26,6 +26,7 @@ public class FooTest {
     @Test
     public void testFight() throws Exception {
         when(fooFighter.fight(any())).thenReturn("fightResponse");
+
         String result = foo.fight(new com.example.foes.Fire(), "foeName");
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }

--- a/testData/testMeGenerator/inheritance/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/inheritance/testGroovy/com/example/services/impl/FooTest.groovy
@@ -24,6 +24,7 @@ class FooTest {
     @Test
     void testFight() {
         when(fooFighter.fight(any())).thenReturn("fightResponse")
+
         java.lang.String result = foo.fight(new com.example.foes.Fire(), "foeName")
         assert result == "replaceMeWithExpectedResult"
     }

--- a/testData/testMeGenerator/mockReturned/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/mockReturned/src/com/example/services/impl/Foo.java
@@ -1,0 +1,22 @@
+package com.example.services.impl;
+
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fear;
+import com.example.foes.Fire;
+import com.example.foes.Ice;
+import com.example.warriers.FooFighter;
+
+public class Foo{
+
+    private FooFighter fooFighter;
+
+    public String fight(Fire withFire,String foeName) {
+        System.out.println(withFire);
+        System.out.println(foeName);
+        ConvertedBean convertedBean = fooFighter.surrender(new Fear(), new Ice(), 666);
+        System.out.println(convertedBean.getFear());
+        System.out.println(convertedBean.getIce());
+        System.out.println(convertedBean.getSomeNum());
+        return "returning response from dependency "+ convertedBean.getMyString();;
+    }
+}

--- a/testData/testMeGenerator/mockReturned/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/mockReturned/src/com/example/services/impl/Foo.java
@@ -1,6 +1,7 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
+import com.example.dependencies.Logger;
 import com.example.foes.Fear;
 import com.example.foes.Fire;
 import com.example.foes.Ice;
@@ -9,14 +10,16 @@ import com.example.warriers.FooFighter;
 public class Foo{
 
     private FooFighter fooFighter;
+    private Logger logger;
 
     public String fight(Fire withFire,String foeName) {
+        logger.trace("this method does not return a value so it should not be stubbed");
         System.out.println(withFire);
         System.out.println(foeName);
         ConvertedBean convertedBean = fooFighter.surrender(new Fear(), new Ice(), 666);
         System.out.println(convertedBean.getFear());
         System.out.println(convertedBean.getIce());
         System.out.println(convertedBean.getSomeNum());
-        return "returning response from dependency "+ convertedBean.getMyString();;
+        return "returning response from dependency "+ convertedBean.getMyString();
     }
 }

--- a/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
@@ -32,6 +32,7 @@ public class FooTest {
     @Test
     public void testFight() throws Exception {
         when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
+
         String result = foo.fight(new Fire(), "foeName");
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }

--- a/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
@@ -1,0 +1,37 @@
+package com.example.services.impl;
+
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fire;
+import com.example.warriers.FooFighter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * created by TestMe integration test on MMXVI
+ */
+public class FooTest {
+    @Mock
+    FooFighter fooFighter;
+    @InjectMocks
+    Foo foo;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testFight() throws Exception {
+        when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
+        String result = foo.fight(new Fire(), "foeName");
+        Assert.assertEquals("replaceMeWithExpectedResult", result);
+    }
+}
+
+//Generated with love by TestMe :) Please report issues and submit feature requests at: http://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
@@ -1,0 +1,35 @@
+package com.example.services.impl
+
+import com.example.beans.ConvertedBean
+import com.example.foes.Fear
+import com.example.foes.Fire
+import com.example.foes.Ice
+import com.example.warriers.FooFighter
+import org.junit.Test
+import org.junit.Before
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import static org.mockito.Mockito.*
+
+/** created by TestMe integration test on MMXVI */
+class FooTest {
+    @Mock
+    FooFighter fooFighter
+    @InjectMocks
+    Foo foo
+
+    @Before
+    void setUp() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    @Test
+    void testFight() {
+        when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean(myString: "myString", someNum: 0, fear: new Fear(), ice: new Ice()))
+        String result = foo.fight(new Fire(), "foeName")
+        assert result == "replaceMeWithExpectedResult"
+    }
+}
+
+//Generated with love by TestMe :) Please report issues and submit feature requests at: http://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
@@ -1,6 +1,7 @@
 package com.example.services.impl
 
 import com.example.beans.ConvertedBean
+import com.example.dependencies.Logger
 import com.example.foes.Fear
 import com.example.foes.Fire
 import com.example.foes.Ice
@@ -16,6 +17,8 @@ import static org.mockito.Mockito.*
 class FooTest {
     @Mock
     FooFighter fooFighter
+    @Mock
+    Logger logger
     @InjectMocks
     Foo foo
 
@@ -27,6 +30,7 @@ class FooTest {
     @Test
     void testFight() {
         when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean(myString: "myString", someNum: 0, fear: new Fear(), ice: new Ice()))
+
         String result = foo.fight(new Fire(), "foeName")
         assert result == "replaceMeWithExpectedResult"
     }

--- a/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
@@ -1,0 +1,33 @@
+package com.example.services.impl;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * created by TestMe integration test on MMXVI
+ */
+class FooTest {
+    @Mock
+    com.example.warriers.FooFighter fooFighter;
+    @InjectMocks
+    Foo foo;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void testFight() {
+        String result = foo.fight(new com.example.foes.Fire(), "foeName");
+        Assertions.assertEquals("replaceMeWithExpectedResult", result);
+    }
+}
+
+//Generated with love by TestMe :) Please report issues and submit feature requests at: http://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
@@ -1,8 +1,11 @@
 package com.example.services.impl;
 
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fire;
+import com.example.warriers.FooFighter;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -14,7 +17,7 @@ import static org.mockito.Mockito.*;
  */
 class FooTest {
     @Mock
-    com.example.warriers.FooFighter fooFighter;
+    FooFighter fooFighter;
     @InjectMocks
     Foo foo;
 
@@ -25,7 +28,8 @@ class FooTest {
 
     @Test
     void testFight() {
-        String result = foo.fight(new com.example.foes.Fire(), "foeName");
+        when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
+        String result = foo.fight(new Fire(), "foeName");
         Assertions.assertEquals("replaceMeWithExpectedResult", result);
     }
 }

--- a/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
@@ -1,6 +1,7 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
+import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.junit.jupiter.api.Assertions;
@@ -18,6 +19,8 @@ import static org.mockito.Mockito.*;
 class FooTest {
     @Mock
     FooFighter fooFighter;
+    @Mock
+    Logger logger;
     @InjectMocks
     Foo foo;
 
@@ -29,6 +32,7 @@ class FooTest {
     @Test
     void testFight() {
         when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
+
         String result = foo.fight(new Fire(), "foeName");
         Assertions.assertEquals("replaceMeWithExpectedResult", result);
     }

--- a/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
@@ -1,0 +1,35 @@
+package com.example.services.impl
+
+import com.example.beans.ConvertedBean
+import com.example.foes.Fear
+import com.example.foes.Fire
+import com.example.foes.Ice
+import com.example.warriers.FooFighter
+import spock.lang.*
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import static org.mockito.Mockito.*
+
+/** created by TestMe integration test on MMXVI */
+class FooTest extends Specification {
+    @Mock
+    FooFighter fooFighter
+    @InjectMocks
+    Foo foo
+
+    def setup() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    def "test fight"() {
+        when:
+        when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean(myString: "myString", someNum: 0, fear: new Fear(), ice: new Ice()))
+        String result = foo.fight(new Fire(), "foeName")
+
+        then:
+        result == "replaceMeWithExpectedResult"
+    }
+}
+
+//Generated with love by TestMe :) Please report issues and submit feature requests at: http://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
@@ -1,6 +1,7 @@
 package com.example.services.impl
 
 import com.example.beans.ConvertedBean
+import com.example.dependencies.Logger
 import com.example.foes.Fear
 import com.example.foes.Fire
 import com.example.foes.Ice
@@ -15,6 +16,8 @@ import static org.mockito.Mockito.*
 class FooTest extends Specification {
     @Mock
     FooFighter fooFighter
+    @Mock
+    Logger logger
     @InjectMocks
     Foo foo
 

--- a/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
@@ -23,8 +23,10 @@ class FooTest extends Specification {
     }
 
     def "test fight"() {
-        when:
+        given:
         when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean(myString: "myString", someNum: 0, fear: new Fear(), ice: new Ice()))
+
+        when:
         String result = foo.fight(new Fire(), "foeName")
 
         then:

--- a/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
@@ -1,0 +1,37 @@
+package com.example.services.impl;
+
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fire;
+import com.example.warriers.FooFighter;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * created by TestMe integration test on MMXVI
+ */
+public class FooTest {
+    @Mock
+    FooFighter fooFighter;
+    @InjectMocks
+    Foo foo;
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testFight() {
+        when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
+        String result = foo.fight(new Fire(), "foeName");
+        Assert.assertEquals(result, "replaceMeWithExpectedResult");
+    }
+}
+
+//Generated with love by TestMe :) Please report issues and submit feature requests at: http://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
@@ -1,6 +1,7 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
+import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.mockito.InjectMocks;
@@ -18,6 +19,8 @@ import static org.mockito.Mockito.*;
 public class FooTest {
     @Mock
     FooFighter fooFighter;
+    @Mock
+    Logger logger;
     @InjectMocks
     Foo foo;
 
@@ -29,6 +32,7 @@ public class FooTest {
     @Test
     public void testFight() {
         when(fooFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
+
         String result = foo.fight(new Fire(), "foeName");
         Assert.assertEquals(result, "replaceMeWithExpectedResult");
     }

--- a/testData/testMeGenerator/paramsConstructors/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/paramsConstructors/test/com/example/services/impl/FooTest.java
@@ -37,6 +37,7 @@ public class FooTest {
 
     @Test
     public void testFight() throws Exception {
+        when(fooFighter.fight(any())).thenReturn("fightResponse");
         BigBean result = foo.fight(new Fire(), Arrays.<String>asList("String"), new BigBean(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood"), new Many("family", "members", "only"), new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood")), new BeanThere(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), new BigBean(null, new Many("family", "members", "only"), null), "ifYourInDaHood"), new Many("family", "members", "only")));
         Assert.assertEquals(new BigBean(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood"), new Many("family", "members", "only"), new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood")), result);
     }

--- a/testData/testMeGenerator/paramsConstructors/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/paramsConstructors/test/com/example/services/impl/FooTest.java
@@ -38,6 +38,7 @@ public class FooTest {
     @Test
     public void testFight() throws Exception {
         when(fooFighter.fight(any())).thenReturn("fightResponse");
+
         BigBean result = foo.fight(new Fire(), Arrays.<String>asList("String"), new BigBean(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood"), new Many("family", "members", "only"), new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood")), new BeanThere(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), new BigBean(null, new Many("family", "members", "only"), null), "ifYourInDaHood"), new Many("family", "members", "only")));
         Assert.assertEquals(new BigBean(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood"), new Many("family", "members", "only"), new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood")), result);
     }

--- a/testData/testMeGenerator/paramsConstructors/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/paramsConstructors/testGroovy/com/example/services/impl/FooTest.groovy
@@ -30,6 +30,7 @@ class FooTest {
     @Test
     void testFight() {
         when(fooFighter.fight(any())).thenReturn("fightResponse")
+
         BigBean result = foo.fight(new Fire(), ["String"], new BigBean(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood"), new Many("family", "members", "only"), new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood")), new BeanThere(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), new BigBean(null, new Many("family", "members", "only"), null), "ifYourInDaHood"), new Many("family", "members", "only")))
         assert result == new BigBean(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood"), new Many("family", "members", "only"), new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood"))
     }

--- a/testData/testMeGenerator/paramsConstructors/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/paramsConstructors/testGroovy/com/example/services/impl/FooTest.groovy
@@ -29,6 +29,7 @@ class FooTest {
 
     @Test
     void testFight() {
+        when(fooFighter.fight(any())).thenReturn("fightResponse")
         BigBean result = foo.fight(new Fire(), ["String"], new BigBean(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood"), new Many("family", "members", "only"), new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood")), new BeanThere(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), new BigBean(null, new Many("family", "members", "only"), null), "ifYourInDaHood"), new Many("family", "members", "only")))
         assert result == new BigBean(new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood"), new Many("family", "members", "only"), new DoneThat(0, "aDay", new Many("family", "members", "only"), new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), null, "ifYourInDaHood"))
     }

--- a/testData/testMeGenerator/replacedInterface/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/replacedInterface/src/com/example/services/impl/Foo.java
@@ -1,0 +1,10 @@
+package com.example.services.impl;
+
+import com.example.dependencies.MasterInterface;
+import com.example.foes.BeanDependsOnInterface;
+
+public class Foo{
+    public MasterInterface jack(BeanDependsOnInterface andTheBeanstalk,MasterInterface masterInterface) {
+        return masterInterface;
+    }
+}

--- a/testData/testMeGenerator/replacedInterface/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/replacedInterface/test/com/example/services/impl/FooTest.java
@@ -1,0 +1,22 @@
+package com.example.services.impl;
+
+import com.example.dependencies.ChildWithSetters;
+import com.example.dependencies.MasterInterface;
+import com.example.foes.BeanDependsOnInterface;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * created by TestMe integration test on MMXVI
+ */
+public class FooTest {
+    Foo foo = new Foo();
+
+    @Test
+    public void testJack() throws Exception {
+        MasterInterface result = foo.jack(new BeanDependsOnInterface(new ChildWithSetters()), new ChildWithSetters());
+        Assert.assertEquals(new ChildWithSetters(), result);
+    }
+}
+
+//Generated with love by TestMe :) Please report issues and submit feature requests at: http://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/replacedInterface/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/replacedInterface/testGroovy/com/example/services/impl/FooTest.groovy
@@ -1,0 +1,24 @@
+package com.example.services.impl
+
+import com.example.beans.JavaBean
+import com.example.dependencies.ChildWithSetters
+import com.example.dependencies.MasterInterface
+import com.example.foes.BeanDependsOnInterface
+import com.example.foes.Fear
+import com.example.foes.Fire
+import com.example.foes.FireBall
+import com.example.foes.Ice
+import org.junit.Test
+
+/** created by TestMe integration test on MMXVI */
+class FooTest {
+    Foo foo = new Foo()
+
+    @Test
+    void testJack() {
+        MasterInterface result = foo.jack(new BeanDependsOnInterface(new ChildWithSetters(strField: "strField", someNumber: 0, fire: new FireBall(new JavaBean(myString: "myString", myDate: new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), someNum: 0, someLongerNum: 1l, fear: null, fire: null, ice: null, myOtherString: "myOtherString", someBinaryOption: true)))), new ChildWithSetters(strField: "strField", someNumber: 0, fire: new FireBall(new JavaBean(myString: "myString", myDate: new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), someNum: 0, someLongerNum: 1l, fear: new Fear(), fire: new Fire(), ice: new Ice(), myOtherString: "myOtherString", someBinaryOption: true))))
+        assert result == new ChildWithSetters(strField: "strField", someNumber: 0, fire: new FireBall(new JavaBean(myString: "myString", myDate: new GregorianCalendar(2016, Calendar.JANUARY, 11, 22, 45).getTime(), someNum: 0, someLongerNum: 1l, fear: new Fear(), fire: new Fire(), ice: new Ice(), myOtherString: "myOtherString", someBinaryOption: true)))
+    }
+}
+
+//Generated with love by TestMe :) Please report issues and submit feature requests at: http://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/variousFieldTypes/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/variousFieldTypes/src/com/example/services/impl/Foo.java
@@ -39,7 +39,8 @@ public class Foo{
 
     public class PublicInnerClass {
         public class InnerOfPublicInnerClass {
-            public void methodOfInnerClass() {
+            public InnerOfPublicInnerClass methodOfInnerClass() {
+                return this;
             }
         }
         public void methodOfInnerClass(){
@@ -71,12 +72,12 @@ public class Foo{
         anonymousPublicInnerClass.methodOfInnerClass();
         innerStaticClass.methodOfInnerClass();
         innerClass.methodOfInnerClass();
-        innerOfPublicInnerClass.methodOfInnerClass();
-        fooFighterDefault.fight(withFire);
-        fooFighterFinal.fight(withFire);
-        fooFighterProtected.fight(withFire);
-        fooFighterPublic.fight(withFire);
-        fooFighterStatic.fight(withFire);
+        System.out.println(innerOfPublicInnerClass.methodOfInnerClass().toString());
+        System.out.println(fooFighterDefault.fight(withFire).toString());
+        System.out.println(fooFighterFinal.fight(withFire).toString());
+        System.out.println(fooFighterProtected.fight(withFire).toString());
+        System.out.println(fooFighterPublic.fight(withFire).toString());
+        System.out.println(fooFighterStatic.fight(withFire).toString());
 
         return fooFighter.fight(withFire);
     }

--- a/testData/testMeGenerator/variousFieldTypes/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/variousFieldTypes/test/com/example/services/impl/FooTest.java
@@ -51,11 +51,8 @@ public class FooTest {
         when(fooFighterPublic.fight(any())).thenReturn("fightResponse");
         when(fooFighterFinal.fight(any())).thenReturn("fightResponse");
         when(fooFighterStatic.fight(any())).thenReturn("fightResponse");
-        when(publicInnerClass.methodOfInnerClass()).thenReturn(null);
-        when(innerStaticClass.methodOfInnerClass()).thenReturn(null);
-        when(innerOfPublicInnerClass.methodOfInnerClass()).thenReturn(null);
-        when(innerClass.methodOfInnerClass()).thenReturn(null);
-        when(anonymousPublicInnerClass.methodOfInnerClass()).thenReturn(null);
+        when(innerOfPublicInnerClass.methodOfInnerClass()).thenReturn(new Foo().new PublicInnerClass().new InnerOfPublicInnerClass());
+
         String result = foo.fight(new com.example.foes.Fire(), "foeName");
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }

--- a/testData/testMeGenerator/variousFieldTypes/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/variousFieldTypes/test/com/example/services/impl/FooTest.java
@@ -45,6 +45,17 @@ public class FooTest {
 
     @Test
     public void testFight() throws Exception {
+        when(fooFighter.fight(any())).thenReturn("fightResponse");
+        when(fooFighterProtected.fight(any())).thenReturn("fightResponse");
+        when(fooFighterDefault.fight(any())).thenReturn("fightResponse");
+        when(fooFighterPublic.fight(any())).thenReturn("fightResponse");
+        when(fooFighterFinal.fight(any())).thenReturn("fightResponse");
+        when(fooFighterStatic.fight(any())).thenReturn("fightResponse");
+        when(publicInnerClass.methodOfInnerClass()).thenReturn(null);
+        when(innerStaticClass.methodOfInnerClass()).thenReturn(null);
+        when(innerOfPublicInnerClass.methodOfInnerClass()).thenReturn(null);
+        when(innerClass.methodOfInnerClass()).thenReturn(null);
+        when(anonymousPublicInnerClass.methodOfInnerClass()).thenReturn(null);
         String result = foo.fight(new com.example.foes.Fire(), "foeName");
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }

--- a/testData/testMeGenerator/variousFieldTypes/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/variousFieldTypes/testGroovy/com/example/services/impl/FooTest.groovy
@@ -47,11 +47,8 @@ class FooTest {
         when(fooFighterPublic.fight(any())).thenReturn("fightResponse")
         when(fooFighterFinal.fight(any())).thenReturn("fightResponse")
         when(fooFighterStatic.fight(any())).thenReturn("fightResponse")
-        when(publicInnerClass.methodOfInnerClass()).thenReturn(null)
-        when(innerStaticClass.methodOfInnerClass()).thenReturn(null)
-        when(innerOfPublicInnerClass.methodOfInnerClass()).thenReturn(null)
-        when(innerClass.methodOfInnerClass()).thenReturn(null)
-        when(anonymousPublicInnerClass.methodOfInnerClass()).thenReturn(null)
+        when(innerOfPublicInnerClass.methodOfInnerClass()).thenReturn(new com.example.services.impl.Foo.PublicInnerClass.InnerOfPublicInnerClass(new com.example.services.impl.Foo.PublicInnerClass(new com.example.services.impl.Foo())))
+
         java.lang.String result = foo.fight(new com.example.foes.Fire(), "foeName")
         assert result == "replaceMeWithExpectedResult"
     }

--- a/testData/testMeGenerator/variousFieldTypes/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/variousFieldTypes/testGroovy/com/example/services/impl/FooTest.groovy
@@ -41,6 +41,17 @@ class FooTest {
 
     @Test
     void testFight() {
+        when(fooFighter.fight(any())).thenReturn("fightResponse")
+        when(fooFighterProtected.fight(any())).thenReturn("fightResponse")
+        when(fooFighterDefault.fight(any())).thenReturn("fightResponse")
+        when(fooFighterPublic.fight(any())).thenReturn("fightResponse")
+        when(fooFighterFinal.fight(any())).thenReturn("fightResponse")
+        when(fooFighterStatic.fight(any())).thenReturn("fightResponse")
+        when(publicInnerClass.methodOfInnerClass()).thenReturn(null)
+        when(innerStaticClass.methodOfInnerClass()).thenReturn(null)
+        when(innerOfPublicInnerClass.methodOfInnerClass()).thenReturn(null)
+        when(innerClass.methodOfInnerClass()).thenReturn(null)
+        when(anonymousPublicInnerClass.methodOfInnerClass()).thenReturn(null)
         java.lang.String result = foo.fight(new com.example.foes.Fire(), "foeName")
         assert result == "replaceMeWithExpectedResult"
     }

--- a/testme-intellij-groovy/src/main/java/com/weirddev/testme/intellij/resolvers/groovy/GroovyPropertyUtil.java
+++ b/testme-intellij-groovy/src/main/java/com/weirddev/testme/intellij/resolvers/groovy/GroovyPropertyUtil.java
@@ -1,0 +1,24 @@
+package com.weirddev.testme.intellij.resolvers.groovy;
+
+import com.intellij.psi.PsiMethod;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.plugins.groovy.lang.psi.util.GroovyPropertyUtils;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: yaron.yamin
+ * Date: 11/1/2017
+ * Time: 4:23 PM
+ */
+/**
+A this wrapper to IJ GroovyPropertyUtils, used to isolate groovy plugin so there will be not attempts to load it at runtime when its not available
+ */
+public class GroovyPropertyUtil
+{
+    public static boolean isPropertySetter(@Nullable PsiMethod method) {
+        return GroovyPropertyUtils.isSimplePropertySetter(method);
+    }
+    public static boolean isPropertyGetter(@Nullable PsiMethod method) {
+        return GroovyPropertyUtils.isSimplePropertyGetter(method);
+    }
+}


### PR DESCRIPTION
Features in v1.7 release:

- Generate mocked return values for method calls of mocked dependencies in tested class
- Test params generator: locate and initialize concrete types found in project source instead of passing null for interface/abstract parameter types
- Get configuration from system properties (a temporary solution to support runtime configuration control via the built in IDE Scripting Console - on the Tools menu). Note: Some of these configuration properties may not be supported in future releases. <a href="http://weirddev.com/blog/testme/testme-configuration-hacks">More info and usage instructions here</a>