### PR TITLE
Replace initMock by openMocks

### DIFF
--- a/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
@@ -21,7 +21,7 @@ class ${CLASS_NAME} {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 #end
 #foreach($method in $TESTED_CLASS.methods)


### PR DESCRIPTION
In Mockito 2 there is a MockitoAnnotations.initMock() method, which is deprecated and replaced with MockitoAnnotations.openMocks() in Mockito 3.