### PR TITLE
for classes with only private constructor exclude mocks

### DIFF
--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorGroovyJunit4Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorGroovyJunit4Test.java
@@ -42,4 +42,9 @@ public class TestMeGeneratorGroovyJunit4Test extends TestMeGeneratorJunit4Test {
     public void testCtorOverSetters() throws Exception{
         doTest(true,true,true,67, false, false);
     }
+
+    public void testUtilWithoutAccessableCtor() {
+        doTest(true, true, true);
+    }
+
 }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
@@ -172,6 +172,9 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
 //       myFixture.copyDirectoryToProject("resources", "resources"); //issue with setting up a resource folder
 //        doTest(true, true, true);
 //    }
+    public void testUtilWithoutAccessableCtor() {
+        doTest(true, true, true);
+    }
 
     //todo TC - use static init method when constructor not available
 

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
@@ -29,4 +29,8 @@ public class TestMeGeneratorJunit5Test extends TestMeGeneratorTestBase {
         doTest(new FileTemplateConfig(TestMeConfigPersistent.getInstance().getState()));
     }
 
+    public void testUtilWithoutAccessableCtor() {
+        doTest(true, true, true);
+    }
+
 }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestNgTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestNgTest.java
@@ -28,4 +28,9 @@ public class TestMeGeneratorTestNgTest extends TestMeGeneratorTestBase {
     public void testMockReturned() throws Exception {
         doTest(new FileTemplateConfig(TestMeConfigPersistent.getInstance().getState()));
     }
+
+    public void testUtilWithoutAccessableCtor() {
+        doTest(true, true, true);
+    }
+
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
@@ -138,7 +138,7 @@ public class  MockitoMockBuilder {
     }
 
     /**
-     * for class with only private constructor can not mock, for example util classes only with static methods
+     * for class with only private constructor that can not mock, for example util classes only with static methods
      * @param testedClass tested class
      * @return true - if tested class has public constructors
      */

--- a/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
@@ -138,6 +138,27 @@ public class  MockitoMockBuilder {
     }
 
     /**
+     * for class with only private constructor can not mock, for example util classes only with static methods
+     * @param testedClass tested class
+     * @return true - if tested class has public constructors
+     */
+    public boolean canMockViaCtors(Type testedClass) {
+        // filter the constructors
+        List<Method> constructorList = testedClass.findConstructors();
+        if (!constructorList.isEmpty()) {
+            boolean hasOnlyPrivateConstructor = true;
+            for (Method method : constructorList) {
+                if (!method.isPrivate()) {
+                    hasOnlyPrivateConstructor = false;
+                    break;
+                }
+            }
+            return !hasOnlyPrivateConstructor;
+        }
+        return true;
+    }
+
+    /**
      * true - if method had any argument that can be mocked given the provided default types
      */
     @SuppressWarnings("unused")

--- a/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
@@ -142,20 +142,19 @@ public class  MockitoMockBuilder {
      * @param testedClass tested class
      * @return true - if tested class has public constructors
      */
-    public boolean canMockViaCtors(Type testedClass) {
+    public boolean hasAccessibleCtor(Type testedClass) {
         // filter the constructors
         List<Method> constructorList = testedClass.findConstructors();
-        if (!constructorList.isEmpty()) {
-            boolean hasOnlyPrivateConstructor = true;
-            for (Method method : constructorList) {
-                if (!method.isPrivate()) {
-                    hasOnlyPrivateConstructor = false;
-                    break;
-                }
-            }
-            return !hasOnlyPrivateConstructor;
-        }
-        return true;
+        return constructorList.isEmpty() || constructorList.stream().anyMatch(method -> !method.isPrivate());
+    }
+
+    /**
+     *
+     * @param testedClass the tested class
+     * @return true - if the tested class has mockable field
+     */
+    public boolean hasMocks(Type testedClass) {
+        return hasAccessibleCtor(testedClass) && hasMockable(testedClass.getFields());
     }
 
     /**

--- a/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
@@ -142,7 +142,7 @@ public class  MockitoMockBuilder {
      * @param testedClass tested class
      * @return true - if tested class has public constructors
      */
-    public boolean hasAccessibleCtor(Type testedClass) {
+    private boolean hasAccessibleCtor(Type testedClass) {
         // filter the constructors
         List<Method> constructorList = testedClass.findConstructors();
         return constructorList.isEmpty() || constructorList.stream().anyMatch(method -> !method.isPrivate());

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
@@ -69,7 +69,7 @@
 #end
 #end
 ##
-#macro(grRenderMockedFields $testedClassFields)
+#macro(grRenderMockedFields $testedClassFields $hasMocks)
 #foreach($field in $testedClassFields)
 #if($hasMocks && $MockitoMockBuilder.isMockable($field))
     @Mock

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
@@ -71,7 +71,7 @@
 ##
 #macro(grRenderMockedFields $testedClassFields)
 #foreach($field in $testedClassFields)
-#if($MockitoMockBuilder.isMockable($field))
+#if($hasMocks && $MockitoMockBuilder.isMockable($field))
     @Mock
     $field.type.canonicalName $field.name
 #elseif($MockitoMockBuilder.isMockExpected($field))

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
@@ -54,16 +54,14 @@
 #end
 ##
 #macro(renderMockedFields $testedClassFields)
-    #if($hasMocks)
-        #foreach($field in $testedClassFields)
-            #if($MockitoMockBuilder.isMockable($field))
-                @Mock
-                $field.type.canonicalName $field.name;
-            #elseif($MockitoMockBuilder.isMockExpected($field))
-                $MockitoMockBuilder.getImmockabiliyReason("//",$field)
-            #end
-        #end
-    #end
+#foreach($field in $testedClassFields)
+#if($hasMocks && $MockitoMockBuilder.isMockable($field))
+    @Mock
+    $field.type.canonicalName $field.name;
+#elseif($MockitoMockBuilder.isMockExpected($field))
+    $MockitoMockBuilder.getImmockabiliyReason("//",$field)
+#end
+#end
 #end
 ##
 #macro(renderJavaReturnVar $type)

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
@@ -54,14 +54,16 @@
 #end
 ##
 #macro(renderMockedFields $testedClassFields)
-#foreach($field in $testedClassFields)
-#if($MockitoMockBuilder.isMockable($field))
-    @Mock
-    $field.type.canonicalName $field.name;
-#elseif($MockitoMockBuilder.isMockExpected($field))
-    $MockitoMockBuilder.getImmockabiliyReason("//",$field)
-#end
-#end
+    #if($hasMocks)
+        #foreach($field in $testedClassFields)
+            #if($MockitoMockBuilder.isMockable($field))
+                @Mock
+                $field.type.canonicalName $field.name;
+            #elseif($MockitoMockBuilder.isMockExpected($field))
+                $MockitoMockBuilder.getImmockabiliyReason("//",$field)
+            #end
+        #end
+    #end
 #end
 ##
 #macro(renderJavaReturnVar $type)

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
@@ -53,7 +53,7 @@
 #end
 #end
 ##
-#macro(renderMockedFields $testedClassFields)
+#macro(renderMockedFields $testedClassFields $hasMocks)
 #foreach($field in $testedClassFields)
 #if($hasMocks && $MockitoMockBuilder.isMockable($field))
     @Mock

--- a/src/main/resources/fileTemplates/testMeTests/Groovy, JUnit4 & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeTests/Groovy, JUnit4 & Mockito.groovy.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.groovy")
-#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMocks($TESTED_CLASS))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME}
 #end
@@ -29,7 +29,7 @@ class ${CLASS_NAME} {
 
     @Test
     void #renderTestMethodName($method.name)() {
-#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+#if($hasMocks && $MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
 #grRenderMockStubs($method,$TESTED_CLASS.fields)
 
 #end

--- a/src/main/resources/fileTemplates/testMeTests/Groovy, JUnit4 & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeTests/Groovy, JUnit4 & Mockito.groovy.ft
@@ -15,7 +15,7 @@ import org.mockito.MockitoAnnotations
 
 #parse("File Header.java")
 class ${CLASS_NAME} {
-#grRenderMockedFields($TESTED_CLASS.fields)
+#grRenderMockedFields($TESTED_CLASS.fields,$hasMocks)
 #grRenderTestSubjectInit($TESTED_CLASS,$TestSubjectUtils.hasTestableInstanceMethod($TESTED_CLASS.methods),$hasMocks)
 #if($hasMocks)
 

--- a/src/main/resources/fileTemplates/testMeTests/Groovy, Spock & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeTests/Groovy, Spock & Mockito.groovy.ft
@@ -13,7 +13,7 @@ import org.mockito.MockitoAnnotations
 
 #parse("File Header.java")
 class ${CLASS_NAME}  extends Specification {
-#grRenderMockedFields($TESTED_CLASS.fields)
+#grRenderMockedFields($TESTED_CLASS.fields,$hasMocks)
 #grRenderTestSubjectInit($TESTED_CLASS,$TestSubjectUtils.hasTestableInstanceMethod($TESTED_CLASS.methods),$hasMocks)
 #if($hasMocks)
 

--- a/src/main/resources/fileTemplates/testMeTests/Groovy, Spock & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeTests/Groovy, Spock & Mockito.groovy.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.groovy")
-#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMocks($TESTED_CLASS))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME}
 #end
@@ -25,7 +25,7 @@ class ${CLASS_NAME}  extends Specification {
 #if($TestSubjectUtils.shouldBeTested($method))
 
     def "test #renderTestMethodNameAsWords($method.name)"() {
-#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+#if($hasMocks && $MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
         given:
 #grRenderMockStubs($method,$TESTED_CLASS.fields)
 

--- a/src/main/resources/fileTemplates/testMeTests/JUnit4 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit4 & Mockito.java.ft
@@ -16,7 +16,7 @@ import org.mockito.MockitoAnnotations;
 
 #parse("File Header.java")
 public class ${CLASS_NAME} {
-#renderMockedFields($TESTED_CLASS.fields)
+#renderMockedFields($TESTED_CLASS.fields,$hasMocks)
 #renderTestSubjectInit($TESTED_CLASS,$TestSubjectUtils.hasTestableInstanceMethod($TESTED_CLASS.methods),$hasMocks)
 #if($hasMocks)
 

--- a/src/main/resources/fileTemplates/testMeTests/JUnit4 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit4 & Mockito.java.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.java")
-#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields) && $MockitoMockBuilder.canMockViaCtors($TESTED_CLASS))
+#set($hasMocks=$MockitoMockBuilder.hasMocks($TESTED_CLASS))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME};
 #end
@@ -30,7 +30,7 @@ public class ${CLASS_NAME} {
 
     @Test
     public void #renderTestMethodName($method.name)() throws Exception {
-#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+#if($hasMocks && $MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
 #renderMockStubs($method,$TESTED_CLASS.fields)
 
 #end

--- a/src/main/resources/fileTemplates/testMeTests/JUnit4 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit4 & Mockito.java.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.java")
-#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields) && $MockitoMockBuilder.canMockViaCtors($TESTED_CLASS))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME};
 #end

--- a/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.java")
-#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields) && $MockitoMockBuilder.canMockViaCtors($TESTED_CLASS))
+#set($hasMocks=$MockitoMockBuilder.hasMocks($TESTED_CLASS))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME};
 #end
@@ -29,7 +29,7 @@ class ${CLASS_NAME} {
 
     @Test
     void #renderTestMethodName($method.name)(){
-#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+#if($hasMocks && $MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
 #renderMockStubs($method,$TESTED_CLASS.fields)
 
 #end

--- a/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
@@ -15,7 +15,7 @@ import org.mockito.MockitoAnnotations;
 #end
 #parse("File Header.java")
 class ${CLASS_NAME} {
-#renderMockedFields($TESTED_CLASS.fields)
+#renderMockedFields($TESTED_CLASS.fields,$hasMocks)
 #renderTestSubjectInit($TESTED_CLASS,$TestSubjectUtils.hasTestableInstanceMethod($TESTED_CLASS.methods),$hasMocks)
 #if($hasMocks)
 

--- a/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.java")
-#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields) && $MockitoMockBuilder.canMockViaConstructor($TESTED_CLASS))
+#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields) && $MockitoMockBuilder.canMockViaCtors($TESTED_CLASS))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME};
 #end

--- a/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.java")
-#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields) && $MockitoMockBuilder.canMockViaConstructor($TESTED_CLASS))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME};
 #end

--- a/src/main/resources/fileTemplates/testMeTests/Parameterized Groovy, Spock & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeTests/Parameterized Groovy, Spock & Mockito.groovy.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.groovy")
-#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMocks($TESTED_CLASS))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME}
 #end
@@ -22,7 +22,7 @@ class ${CLASS_NAME}  extends Specification {
     }
 #end
 #foreach($method in $TESTED_CLASS.methods)
-#if($TestSubjectUtils.shouldBeTested($method))
+#if($hasMocks && $TestSubjectUtils.shouldBeTested($method))
 #set($paraTestComponents=$TestBuilder.buildPrameterizedTestComponents($method,$grReplacementTypesForReturn,$grReplacementTypes,$grDefaultTypeValues))
 
     @Unroll

--- a/src/main/resources/fileTemplates/testMeTests/Parameterized Groovy, Spock & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeTests/Parameterized Groovy, Spock & Mockito.groovy.ft
@@ -13,7 +13,7 @@ import org.mockito.MockitoAnnotations
 
 #parse("File Header.java")
 class ${CLASS_NAME}  extends Specification {
-#grRenderMockedFields($TESTED_CLASS.fields)
+#grRenderMockedFields($TESTED_CLASS.fields,$hasMocks)
 #grRenderTestSubjectInit($TESTED_CLASS,$TestSubjectUtils.hasTestableInstanceMethod($TESTED_CLASS.methods),$hasMocks)
 #if($hasMocks)
 

--- a/src/main/resources/fileTemplates/testMeTests/Parameterized Groovy, Spock & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeTests/Parameterized Groovy, Spock & Mockito.groovy.ft
@@ -22,12 +22,12 @@ class ${CLASS_NAME}  extends Specification {
     }
 #end
 #foreach($method in $TESTED_CLASS.methods)
-#if($hasMocks && $TestSubjectUtils.shouldBeTested($method))
+#if($TestSubjectUtils.shouldBeTested($method))
 #set($paraTestComponents=$TestBuilder.buildPrameterizedTestComponents($method,$grReplacementTypesForReturn,$grReplacementTypes,$grDefaultTypeValues))
 
     @Unroll
     def "#renderTestMethodNameAsWords($method.name)$TestSubjectUtils.formatSpockParamNamesTitle($paraTestComponents.paramsMap, $method.hasReturn())"() {
-#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+#if($hasMocks && $MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
         given:
 #grRenderMockStubs($method,$TESTED_CLASS.fields)
 

--- a/src/main/resources/fileTemplates/testMeTests/Specs2 & Mockito.scala.ft
+++ b/src/main/resources/fileTemplates/testMeTests/Specs2 & Mockito.scala.ft
@@ -30,7 +30,7 @@ class ${CLASS_NAME} extends Specification #if($hasMocks) with Mockito#end{
 #if($TestSubjectUtils.shouldBeTested($method))
 
       "#renderTestMethodNameAsWords($method.name)" in {
-#if($MockitoMockBuilder.shouldStub($method,$constructor,$scDefaultTypeValues))
+#if($hasMocks && $MockitoMockBuilder.shouldStub($method,$constructor,$scDefaultTypeValues))
 #scRenderMockStubs($method, $constructor)
 #end
 $TAB$TAB#scRenderMethodCall($method,$TESTED_CLASS)

--- a/src/main/resources/fileTemplates/testMeTests/TestNG & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/TestNG & Mockito.java.ft
@@ -15,7 +15,7 @@ import org.mockito.MockitoAnnotations;
 #end
 #parse("File Header.java")
 public class ${CLASS_NAME} {
-#renderMockedFields($TESTED_CLASS.fields)
+#renderMockedFields($TESTED_CLASS.fields,$hasMocks)
 #renderTestSubjectInit($TESTED_CLASS,$TestSubjectUtils.hasTestableInstanceMethod($TESTED_CLASS.methods),$hasMocks)
 #if($hasMocks)
 

--- a/src/main/resources/fileTemplates/testMeTests/TestNG & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/TestNG & Mockito.java.ft
@@ -1,5 +1,5 @@
 #parse("TestMe macros.java")
-#set($hasMocks=$MockitoMockBuilder.hasMockable($TESTED_CLASS.fields))
+#set($hasMocks=$MockitoMockBuilder.hasMocks($TESTED_CLASS))
 #if($PACKAGE_NAME)
 package ${PACKAGE_NAME};
 #end
@@ -29,7 +29,7 @@ public class ${CLASS_NAME} {
 
     @Test
     public void #renderTestMethodName($method.name)(){
-#if($MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
+#if($hasMocks && $MockitoMockBuilder.shouldStub($method,$TESTED_CLASS.fields))
 #renderMockStubs($method,$TESTED_CLASS.fields)
 
 #end

--- a/testData/testMeGenerator/utilWithoutAccessableCtor/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/utilWithoutAccessableCtor/src/com/example/services/impl/Foo.java
@@ -5,9 +5,10 @@ import com.example.foes.Fire;
 <caret>
 public class Foo {
 
-    private static final FooFighter fooFighter = new FearFighterImpl();
+    private static FooFighter fooFighter = new FearFighterImpl();
 
     public static String fight(Fire withFire,String foeName) {
+        fooFighter.fight(withFire);
         return foeName;
     }
     

--- a/testData/testMeGenerator/utilWithoutAccessableCtor/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/utilWithoutAccessableCtor/src/com/example/services/impl/Foo.java
@@ -1,0 +1,18 @@
+package com.example.services.impl;
+
+import com.example.warriers.FooFighter;
+import com.example.foes.Fire;
+<caret>
+public class Foo {
+
+    private static final FooFighter fooFighter = new FearFighterImpl();
+
+    public static String fight(Fire withFire,String foeName) {
+        return foeName;
+    }
+    
+    private Foo() {
+
+    }
+
+}

--- a/testData/testMeGenerator/utilWithoutAccessableCtor/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/utilWithoutAccessableCtor/test/com/example/services/impl/FooTest.java
@@ -1,0 +1,19 @@
+package com.example.services.impl;
+
+import com.example.foes.Fire;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * created by TestMe integration test on MMXVI
+ */
+public class FooTest {
+
+    @Test
+    public void testFight() throws Exception {
+        String result = Foo.fight(new Fire(), "foeName");
+        Assert.assertEquals("replaceMeWithExpectedResult", result);
+    }
+}
+
+//Generated with love by TestMe :) Please raise issues & feature requests at: https://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/utilWithoutAccessableCtor/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/utilWithoutAccessableCtor/testGroovy/com/example/services/impl/FooTest.groovy
@@ -1,0 +1,16 @@
+package com.example.services.impl
+
+import com.example.foes.Fire
+import org.junit.Test
+
+/** created by TestMe integration test on MMXVI */
+class FooTest {
+
+    @Test
+    void testFight() {
+        String result = Foo.fight(new Fire(), "foeName")
+        assert result == "replaceMeWithExpectedResult"
+    }
+}
+
+//Generated with love by TestMe :) Please raise issues & feature requests at: https://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/utilWithoutAccessableCtor/testJunit5/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/utilWithoutAccessableCtor/testJunit5/com/example/services/impl/FooTest.java
@@ -1,0 +1,19 @@
+package com.example.services.impl;
+
+import com.example.foes.Fire;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * created by TestMe integration test on MMXVI
+ */
+class FooTest {
+
+    @Test
+    void testFight() {
+        String result = Foo.fight(new Fire(), "foeName");
+        Assertions.assertEquals("replaceMeWithExpectedResult", result);
+    }
+}
+
+//Generated with love by TestMe :) Please raise issues & feature requests at: https://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/utilWithoutAccessableCtor/testTestNg/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/utilWithoutAccessableCtor/testTestNg/com/example/services/impl/FooTest.java
@@ -1,0 +1,19 @@
+package com.example.services.impl;
+
+import com.example.foes.Fire;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * created by TestMe integration test on MMXVI
+ */
+public class FooTest {
+
+    @Test
+    public void testFight() {
+        String result = Foo.fight(new Fire(), "foeName");
+        Assert.assertEquals(result, "replaceMeWithExpectedResult");
+    }
+}
+
+//Generated with love by TestMe :) Please raise issues & feature requests at: https://weirddev.com/forum#!/testme


### PR DESCRIPTION
for classes with only private constructor exclude mocks，

for example tested class like
````java
import com.alibaba.fastjson.JSONArray;
import com.alibaba.fastjson.JSONObject;
import com.unicom.tdt.admin.model.exception.ResponseException;
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;
import org.springframework.util.Base64Utils;

import javax.crypto.Cipher;

import javax.crypto.spec.GCMParameterSpec;
import javax.crypto.spec.SecretKeySpec;
import java.nio.charset.StandardCharsets;
import java.util.Map;

public class AesUtil {

    private AesUtil(){
        throw new IllegalStateException("Utility class");
    }
    private static Logger logger = LoggerFactory.getLogger(AesUtil.class);

    private static final String KEY_ALGORITHM = "AES";

    private static final String DEFAULT_CIPHER_ALGORITHM = "AES/GCM/NoPadding";


    public static String encrypt(String content, String password) {
    }

    public static String encrypt(Object object,String field, String password) {
    }

    public static String decrypt(String content, String password) {
    }

    public static void decrypt(Object object,String field,String privateKey) throws Exception {
     }
}

````

the generated test class is , the mock should be removed
````java
import org.junit.Assert;
import org.junit.Before;
import org.junit.Test;
import org.mockito.InjectMocks;
import org.mockito.Mock;
import org.mockito.MockitoAnnotations;
import org.slf4j.Logger;

import static org.mockito.Mockito.*;

public class AesUtilTest44 {
    @Mock
    Logger logger;
    @InjectMocks
    AesUtil aesUtil;

    @Before
    public void setUp() {
        MockitoAnnotations.initMocks(this);
    }

    @Test
    public void testEncrypt() throws Exception {
        String result = AesUtil.encrypt("content", "password");
        Assert.assertEquals("replaceMeWithExpectedResult", result);
    }

    @Test
    public void testEncrypt2() throws Exception {
        String result = AesUtil.encrypt("object", "field", "password");
        Assert.assertEquals("replaceMeWithExpectedResult", result);
    }

    @Test
    public void testDecrypt() throws Exception {
        String result = AesUtil.decrypt("content", "password");
        Assert.assertEquals("replaceMeWithExpectedResult", result);
    }

    @Test
    public void testDecrypt2() throws Exception {
        AesUtil.decrypt("object", "field", "privateKey");
    }
}

// Generated with love by TestMe :) Please report issues and submit feature requests at:
// http://weirddev.com/forum#!/testme
````