### PR TITLE
Feature/add verify

### DIFF
--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorGroovyJunit4Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorGroovyJunit4Test.java
@@ -1,5 +1,7 @@
 package com.weirddev.testme.intellij.generator;
 
+import com.weirddev.testme.intellij.configuration.TestMeConfigPersistent;
+import com.weirddev.testme.intellij.template.FileTemplateConfig;
 import com.weirddev.testme.intellij.template.TemplateRegistry;
 import com.weirddev.testme.intellij.template.context.Language;
 
@@ -47,4 +49,7 @@ public class TestMeGeneratorGroovyJunit4Test extends TestMeGeneratorJunit4Test {
         doTest(true, true, true);
     }
 
+    public void testVerifyMethodCall() {
+        doTest(new FileTemplateConfig(TestMeConfigPersistent.getInstance().getState()));
+    }
 }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
@@ -176,6 +176,10 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         doTest(true, true, true);
     }
 
+    public void testVerifyMethodCall() {
+        doTest(new FileTemplateConfig(TestMeConfigPersistent.getInstance().getState()));
+    }
+
     //todo TC - use static init method when constructor not available
 
      // TODO TC different test target dir

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
@@ -33,4 +33,7 @@ public class TestMeGeneratorJunit5Test extends TestMeGeneratorTestBase {
         doTest(true, true, true);
     }
 
+    public void testVerifyMethodCall() {
+        doTest(new FileTemplateConfig(TestMeConfigPersistent.getInstance().getState()));
+    }
 }

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestNgTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestNgTest.java
@@ -33,4 +33,8 @@ public class TestMeGeneratorTestNgTest extends TestMeGeneratorTestBase {
         doTest(true, true, true);
     }
 
+    public void testVerifyMethodCall() {
+        doTest(new FileTemplateConfig(TestMeConfigPersistent.getInstance().getState()));
+    }
+
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Method.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Method.java
@@ -138,10 +138,18 @@ public class Method {
 
     /**
      *
-     * true - if method has a return type
+     * true - if method has a return type and not void
      */
     public boolean hasReturn(){
         return returnType != null && !"void".equals(returnType.getName());
+    }
+
+    /**
+     *
+     * @return true - if the method has a void return type
+     */
+    public boolean hasVoidReturn() {
+        return returnType != null && "void".equals(returnType.getName());
     }
 
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/context/Method.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Method.java
@@ -144,12 +144,4 @@ public class Method {
         return returnType != null && !"void".equals(returnType.getName());
     }
 
-    /**
-     *
-     * @return true - if the method has a void return type
-     */
-    public boolean hasVoidReturn() {
-        return returnType != null && "void".equals(returnType.getName());
-    }
-
 }

--- a/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
@@ -256,7 +256,7 @@ public class  MockitoMockBuilder {
      */
     @SuppressWarnings("unused")
     public boolean shouldVerify(Method testMethod, List<Field> testedClassFields) {
-        return callsMockMethod(testMethod, testedClassFields, Method::hasVoidReturn);
+        return callsMockMethod(testMethod, testedClassFields, method -> !method.hasReturn());
     }
 
     private boolean callsMockMethod(Method testMethod, List<Field> testedClassFields,

--- a/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
@@ -270,6 +270,9 @@ public class  MockitoMockBuilder {
      */
     @SuppressWarnings("unused")
     public boolean shouldVerify(Method testMethod, List<Field> testedClassFields) {
+        if (!stubMockMethodCallsReturnValues) {
+            return false;
+        }
         boolean shouldVerity = false;
         for (Field testedClassField : testedClassFields) {
             if (isMockable(testedClassField)) {

--- a/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/MockitoMockBuilder.java
@@ -264,6 +264,28 @@ public class  MockitoMockBuilder {
     }
 
     /**
+     * true - if should verify tested method
+     * @param testMethod method being tested
+     * @param testedClassFields fields of owner type being tested
+     */
+    @SuppressWarnings("unused")
+    public boolean shouldVerify(Method testMethod, List<Field> testedClassFields) {
+        boolean shouldVerity = false;
+        for (Field testedClassField : testedClassFields) {
+            if (isMockable(testedClassField)) {
+                for (Method fieldMethod : testedClassField.getType().getMethods()) {
+                    if (fieldMethod.getReturnType() != null && "void".equals(fieldMethod.getReturnType().getCanonicalName()) && testSubjectInspector.isMethodCalled(fieldMethod, testMethod)) {
+                        shouldVerity = true;
+                        break;
+                    }
+                }
+            }
+        }
+        LOG.debug("method "+testMethod.getMethodId()+" should be verified:"+shouldVerity);
+        return shouldVerity;
+    }
+
+    /**
      * true - if tested method should be stubbed
      * @param testMethod - method being tested
      * @param ctor - constructor of method return type

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
@@ -108,7 +108,7 @@ result#if($TestSubjectUtils.isJavaFuture($method.returnType)).get()#end == $Test
 #foreach($field in $testedClassFields)
 #if($MockitoMockBuilder.isMockable($field))
 #foreach($fieldMethod in $field.type.methods)
-#if($fieldMethod.hasVoidReturn() && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
+#if(!$fieldMethod.hasReturn() && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
         verify($field.name).${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams},"Java"))
 #end
 #end

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
@@ -103,3 +103,15 @@ result#if($TestSubjectUtils.isJavaFuture($method.returnType)).get()#end == $Test
 #end
 #end
 #end
+##
+#macro(grRenderMockVerifies $method $testedClassFields)
+#foreach($field in $testedClassFields)
+#if($MockitoMockBuilder.isMockable($field))
+#foreach($fieldMethod in $field.type.methods)
+#if($fieldMethod.returnType && $fieldMethod.returnType.name =="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
+        verify($field.name).${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams},"Java"))
+#end
+#end
+#end
+#end
+#end

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.groovy.ft
@@ -96,7 +96,7 @@ result#if($TestSubjectUtils.isJavaFuture($method.returnType)).get()#end == $Test
 #foreach($field in $testedClassFields)
 #if($MockitoMockBuilder.isMockable($field))
 #foreach($fieldMethod in $field.type.methods)
-#if($fieldMethod.returnType && $fieldMethod.returnType.name !="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
+#if($fieldMethod.hasReturn() && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
         when($field.name.${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams},"Java"))).thenReturn($TestBuilder.renderReturnParam($method,$fieldMethod.returnType,"${fieldMethod.name}Response",$grReplacementTypes,$grDefaultTypeValues))
 #end
 #end
@@ -108,7 +108,7 @@ result#if($TestSubjectUtils.isJavaFuture($method.returnType)).get()#end == $Test
 #foreach($field in $testedClassFields)
 #if($MockitoMockBuilder.isMockable($field))
 #foreach($fieldMethod in $field.type.methods)
-#if($fieldMethod.returnType && $fieldMethod.returnType.name =="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
+#if($fieldMethod.hasVoidReturn() && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
         verify($field.name).${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams},"Java"))
 #end
 #end

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
@@ -100,7 +100,7 @@ assertEquals(result#{if}($TestSubjectUtils.isJavaFuture($method.returnType)).get
 #foreach($field in $testedClassFields)
 #if($MockitoMockBuilder.isMockable($field))
 #foreach($fieldMethod in $field.type.methods)
-#if($fieldMethod.hasVoidReturn() && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
+#if(!$fieldMethod.hasReturn() && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
         verify($field.name).${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams},"Java"));
 #end
 #end

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
@@ -88,7 +88,7 @@ assertEquals(result#{if}($TestSubjectUtils.isJavaFuture($method.returnType)).get
 #foreach($field in $testedClassFields)
 #if($MockitoMockBuilder.isMockable($field))
 #foreach($fieldMethod in $field.type.methods)
-#if($fieldMethod.returnType && $fieldMethod.returnType.name !="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
+#if($fieldMethod.hasReturn() && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
         when($field.name.${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams},"Java"))).thenReturn($TestBuilder.renderReturnParam($method,$fieldMethod.returnType,"${fieldMethod.name}Response",$replacementTypes,$defaultTypeValues));
 #end
 #end
@@ -96,11 +96,11 @@ assertEquals(result#{if}($TestSubjectUtils.isJavaFuture($method.returnType)).get
 #end
 #end
 ##
-#macro(renderMockVerifies $method $$testedClassFields)
+#macro(renderMockVerifies $method $testedClassFields)
 #foreach($field in $testedClassFields)
 #if($MockitoMockBuilder.isMockable($field))
 #foreach($fieldMethod in $field.type.methods)
-#if($fieldMethod.returnType && $fieldMethod.returnType.name =="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
+#if($fieldMethod.hasVoidReturn() && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
         verify($field.name).${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams},"Java"));
 #end
 #end

--- a/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
+++ b/src/main/resources/fileTemplates/testMeIncludes/TestMe macros.java.ft
@@ -95,3 +95,15 @@ assertEquals(result#{if}($TestSubjectUtils.isJavaFuture($method.returnType)).get
 #end
 #end
 #end
+##
+#macro(renderMockVerifies $method $$testedClassFields)
+#foreach($field in $testedClassFields)
+#if($MockitoMockBuilder.isMockable($field))
+#foreach($fieldMethod in $field.type.methods)
+#if($fieldMethod.returnType && $fieldMethod.returnType.name =="void" && $TestSubjectUtils.isMethodCalled($fieldMethod,$method))
+        verify($field.name).${fieldMethod.name}($MockitoMockBuilder.buildMockArgsMatchers(${fieldMethod.methodParams},"Java"));
+#end
+#end
+#end
+#end
+#end

--- a/src/main/resources/fileTemplates/testMeTests/Groovy, JUnit4 & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeTests/Groovy, JUnit4 & Mockito.groovy.ft
@@ -34,6 +34,10 @@ class ${CLASS_NAME} {
 
 #end
 $TAB$TAB#grRenderMethodCall($method,$TESTED_CLASS.name)
+
+#if($hasMocks && $MockitoMockBuilder.shouldVerify($method,$TESTED_CLASS.fields))
+#grRenderMockVerifies($method,$TESTED_CLASS.fields)
+#end
 #if($method.hasReturn())
         assert #grRenderAssert($method)
 #end

--- a/src/main/resources/fileTemplates/testMeTests/Groovy, JUnit4 & Mockito.groovy.ft
+++ b/src/main/resources/fileTemplates/testMeTests/Groovy, JUnit4 & Mockito.groovy.ft
@@ -34,7 +34,6 @@ class ${CLASS_NAME} {
 
 #end
 $TAB$TAB#grRenderMethodCall($method,$TESTED_CLASS.name)
-
 #if($hasMocks && $MockitoMockBuilder.shouldVerify($method,$TESTED_CLASS.fields))
 #grRenderMockVerifies($method,$TESTED_CLASS.fields)
 #end

--- a/src/main/resources/fileTemplates/testMeTests/JUnit4 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit4 & Mockito.java.ft
@@ -35,7 +35,6 @@ public class ${CLASS_NAME} {
 
 #end
 $TAB$TAB#renderMethodCall($method,$TESTED_CLASS.name)
-
 #if($hasMocks && $MockitoMockBuilder.shouldVerify($method,$TESTED_CLASS.fields))
 #renderMockVerifies($method,$TESTED_CLASS.fields)
 #end

--- a/src/main/resources/fileTemplates/testMeTests/JUnit4 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit4 & Mockito.java.ft
@@ -35,6 +35,10 @@ public class ${CLASS_NAME} {
 
 #end
 $TAB$TAB#renderMethodCall($method,$TESTED_CLASS.name)
+
+#if($hasMocks && $MockitoMockBuilder.shouldVerify($method,$TESTED_CLASS.fields))
+#renderMockVerifies($method,$TESTED_CLASS.fields)
+#end
 #if($method.hasReturn())
         Assert.#renderJUnitAssert($method)#end
     }

--- a/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
@@ -34,7 +34,6 @@ class ${CLASS_NAME} {
 
 #end
 $TAB$TAB#renderMethodCall($method,$TESTED_CLASS.name)
-
 #if($hasMocks && $MockitoMockBuilder.shouldVerify($method,$TESTED_CLASS.fields))
 #renderMockVerifies($method,$TESTED_CLASS.fields)
 #end

--- a/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/JUnit5 & Mockito.java.ft
@@ -34,6 +34,10 @@ class ${CLASS_NAME} {
 
 #end
 $TAB$TAB#renderMethodCall($method,$TESTED_CLASS.name)
+
+#if($hasMocks && $MockitoMockBuilder.shouldVerify($method,$TESTED_CLASS.fields))
+#renderMockVerifies($method,$TESTED_CLASS.fields)
+#end
 #if($method.hasReturn())        Assertions.#renderJUnitAssert($method)#end
     }
 #end

--- a/src/main/resources/fileTemplates/testMeTests/TestNG & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/TestNG & Mockito.java.ft
@@ -34,6 +34,10 @@ public class ${CLASS_NAME} {
 
 #end
 $TAB$TAB#renderMethodCall($method,$TESTED_CLASS.name)
+
+#if($hasMocks && $MockitoMockBuilder.shouldVerify($method,$TESTED_CLASS.fields))
+#renderMockVerifies($method,$TESTED_CLASS.fields)
+#end
 #if($method.hasReturn())        Assert.#renderTestNgAssert($method)#end
     }
 #end

--- a/src/main/resources/fileTemplates/testMeTests/TestNG & Mockito.java.ft
+++ b/src/main/resources/fileTemplates/testMeTests/TestNG & Mockito.java.ft
@@ -34,7 +34,6 @@ public class ${CLASS_NAME} {
 
 #end
 $TAB$TAB#renderMethodCall($method,$TESTED_CLASS.name)
-
 #if($hasMocks && $MockitoMockBuilder.shouldVerify($method,$TESTED_CLASS.fields))
 #renderMockVerifies($method,$TESTED_CLASS.fields)
 #end

--- a/testData/commonSrc/com/example/warriers/TechFighter.java
+++ b/testData/commonSrc/com/example/warriers/TechFighter.java
@@ -1,0 +1,13 @@
+package com.example.warriers;
+
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fear;
+import com.example.foes.Fire;
+import com.example.foes.Ice;
+
+/** Test input class*/
+public interface TechFighter {
+    void initSelfArming(String weapon)
+    String fight(Fire withFire);
+    ConvertedBean surrender(Fear fear, Ice ice,int times);
+}

--- a/testData/commonSrc/com/example/warriers/impl/TechFighterImpl.java
+++ b/testData/commonSrc/com/example/warriers/impl/TechFighterImpl.java
@@ -1,0 +1,31 @@
+package com.example.warriers.impl;
+
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fear;
+import com.example.foes.Fire;
+import com.example.foes.Ice;
+import com.example.warriers.TechFighter;
+
+/** Test input class*/
+public class TechFighterImpl implements TechFighter {
+
+    private String weapon;
+
+    @Override
+    public String fight(Fire withFire) {
+        return "flames";
+    }
+
+    @Override
+    public ConvertedBean surrender(Fear fear, Ice ice,int times) {
+        System.out.println("times:" + times);
+        System.out.println("fear:" + fear.toString());
+        return new ConvertedBean();
+    }
+
+    @Override
+    public void initSelfArming(String weapon) {
+        this.weapon = weapon;
+    }
+
+}

--- a/testData/testMeGenerator/mockReturned/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/mockReturned/src/com/example/services/impl/Foo.java
@@ -12,8 +12,10 @@ public class Foo{
 
     private FooFighter fooFighter;
     private Supplier<Integer> result;
+    private Logger logger;
 
     public String fight(Fire withFire,String foeName) {
+        logger.trace("this method does not return a value so it should not be stubbed");
         System.out.println(withFire);
         System.out.println(foeName);
         ConvertedBean convertedBean = fooFighter.surrender(new Fear(), new Ice(), 666);

--- a/testData/testMeGenerator/mockReturned/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/mockReturned/src/com/example/services/impl/Foo.java
@@ -12,10 +12,8 @@ public class Foo{
 
     private FooFighter fooFighter;
     private Supplier<Integer> result;
-    private Logger logger;
 
     public String fight(Fire withFire,String foeName) {
-        logger.trace("this method does not return a value so it should not be stubbed");
         System.out.println(withFire);
         System.out.println(foeName);
         ConvertedBean convertedBean = fooFighter.surrender(new Fear(), new Ice(), 666);

--- a/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
@@ -1,7 +1,6 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
-import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.junit.Assert;
@@ -23,8 +22,6 @@ public class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
-    @Mock
-    Logger logger;
     @InjectMocks
     Foo foo;
 

--- a/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
@@ -1,6 +1,7 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
+import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.junit.Assert;
@@ -22,6 +23,8 @@ public class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
+    @Mock
+    Logger logger;
     @InjectMocks
     Foo foo;
 
@@ -36,6 +39,7 @@ public class FooTest {
         when(result.get()).thenReturn(Integer.valueOf(0));
 
         String result = foo.fight(new Fire(), "foeName");
+        verify(logger).trace(anyString());
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }
 }

--- a/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
@@ -1,7 +1,6 @@
 package com.example.services.impl
 
 import com.example.beans.ConvertedBean
-import com.example.dependencies.Logger
 import com.example.foes.Fear
 import com.example.foes.Fire
 import com.example.foes.Ice
@@ -21,8 +20,6 @@ class FooTest {
     FooFighter fooFighter
     @Mock
     Supplier<Integer> result
-    @Mock
-    Logger logger
     @InjectMocks
     Foo foo
 

--- a/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
@@ -1,6 +1,7 @@
 package com.example.services.impl
 
 import com.example.beans.ConvertedBean
+import com.example.dependencies.Logger
 import com.example.foes.Fear
 import com.example.foes.Fire
 import com.example.foes.Ice
@@ -20,6 +21,8 @@ class FooTest {
     FooFighter fooFighter
     @Mock
     Supplier<Integer> result
+    @Mock
+    Logger logger
     @InjectMocks
     Foo foo
 
@@ -34,6 +37,7 @@ class FooTest {
         when(result.get()).thenReturn(0)
 
         String result = foo.fight(new Fire(), "foeName")
+        verify(logger).trace(anyString())
         assert result == "replaceMeWithExpectedResult"
     }
 }

--- a/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
@@ -1,7 +1,6 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
-import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.junit.jupiter.api.Assertions;
@@ -23,8 +22,6 @@ class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
-    @Mock
-    Logger logger;
     @InjectMocks
     Foo foo;
 

--- a/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
@@ -1,6 +1,7 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
+import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.junit.jupiter.api.Assertions;
@@ -22,6 +23,8 @@ class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
+    @Mock
+    Logger logger;
     @InjectMocks
     Foo foo;
 
@@ -36,6 +39,7 @@ class FooTest {
         when(result.get()).thenReturn(Integer.valueOf(0));
 
         String result = foo.fight(new Fire(), "foeName");
+        verify(logger).trace(anyString());
         Assertions.assertEquals("replaceMeWithExpectedResult", result);
     }
 }

--- a/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
@@ -1,7 +1,6 @@
 package com.example.services.impl
 
 import com.example.beans.ConvertedBean
-import com.example.dependencies.Logger
 import com.example.foes.Fear
 import com.example.foes.Fire
 import com.example.foes.Ice
@@ -20,8 +19,6 @@ class FooTest extends Specification {
     FooFighter fooFighter
     @Mock
     Supplier<Integer> result
-    @Mock
-    Logger logger
     @InjectMocks
     Foo foo
 

--- a/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
@@ -1,6 +1,7 @@
 package com.example.services.impl
 
 import com.example.beans.ConvertedBean
+import com.example.dependencies.Logger
 import com.example.foes.Fear
 import com.example.foes.Fire
 import com.example.foes.Ice
@@ -19,6 +20,8 @@ class FooTest extends Specification {
     FooFighter fooFighter
     @Mock
     Supplier<Integer> result
+    @Mock
+    Logger logger
     @InjectMocks
     Foo foo
 

--- a/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
@@ -1,6 +1,7 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
+import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.mockito.InjectMocks;
@@ -22,6 +23,8 @@ public class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
+    @Mock
+    Logger logger;
     @InjectMocks
     Foo foo;
 

--- a/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
@@ -39,6 +39,7 @@ public class FooTest {
         when(result.get()).thenReturn(Integer.valueOf(0));
 
         String result = foo.fight(new Fire(), "foeName");
+        verify(logger).trace(anyString());
         Assert.assertEquals(result, "replaceMeWithExpectedResult");
     }
 }

--- a/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
@@ -1,7 +1,6 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
-import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.mockito.InjectMocks;
@@ -23,8 +22,6 @@ public class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
-    @Mock
-    Logger logger;
     @InjectMocks
     Foo foo;
 

--- a/testData/testMeGenerator/variousFieldTypes/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/variousFieldTypes/test/com/example/services/impl/FooTest.java
@@ -54,6 +54,10 @@ public class FooTest {
         when(innerOfPublicInnerClass.methodOfInnerClass()).thenReturn(new Foo().new PublicInnerClass().new InnerOfPublicInnerClass());
 
         String result = foo.fight(new com.example.foes.Fire(), "foeName");
+        verify(publicInnerClass).methodOfInnerClass();
+        verify(innerStaticClass).methodOfInnerClass();
+        verify(innerClass).methodOfInnerClass();
+        verify(anonymousPublicInnerClass).methodOfInnerClass();
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }
 }

--- a/testData/testMeGenerator/variousFieldTypes/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/variousFieldTypes/testGroovy/com/example/services/impl/FooTest.groovy
@@ -50,6 +50,10 @@ class FooTest {
         when(innerOfPublicInnerClass.methodOfInnerClass()).thenReturn(new com.example.services.impl.Foo.PublicInnerClass.InnerOfPublicInnerClass(new com.example.services.impl.Foo.PublicInnerClass(new com.example.services.impl.Foo())))
 
         java.lang.String result = foo.fight(new com.example.foes.Fire(), "foeName")
+        verify(publicInnerClass).methodOfInnerClass()
+        verify(innerStaticClass).methodOfInnerClass()
+        verify(innerClass).methodOfInnerClass()
+        verify(anonymousPublicInnerClass).methodOfInnerClass()
         assert result == "replaceMeWithExpectedResult"
     }
 }

--- a/testData/testMeGenerator/verifyMethodCall/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/verifyMethodCall/src/com/example/services/impl/Foo.java
@@ -1,0 +1,23 @@
+package com.example.services.impl;
+
+import com.example.beans.ConvertedBean;
+import java.util.function.Supplier;
+import com.example.dependencies.Logger;
+import com.example.foes.Fear;
+import com.example.foes.Fire;
+import com.example.foes.Ice;
+import com.example.warriers.TechFighter;
+
+public class Foo{
+
+    private TechFighter techFighter;
+    private Supplier<Integer> result;
+
+    public String fight(Fire withFire,String foeName) {
+        techFighter.initSelfArming("gun");
+        String fail = techFighter.fight(withFire);
+        ConvertedBean convertedBean = techFighter.surrender(new Fear(), new Ice(), 666);
+        convertedBean.setSomeNum(result.get());
+        return "returning response from dependency "+ fail + " " + convertedBean.getMyString();
+    }
+}

--- a/testData/testMeGenerator/verifyMethodCall/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/verifyMethodCall/test/com/example/services/impl/FooTest.java
@@ -1,0 +1,46 @@
+package com.example.services.impl;
+
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fire;
+import com.example.warriers.TechFighter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * created by TestMe integration test on MMXVI
+ */
+public class FooTest {
+    @Mock
+    TechFighter techFighter;
+    @Mock
+    Supplier<Integer> result;
+    @InjectMocks
+    Foo foo;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testFight() throws Exception {
+        when(techFighter.fight(any())).thenReturn("fightResponse");
+        when(techFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
+        when(result.get()).thenReturn(Integer.valueOf(0));
+
+        String result = foo.fight(new Fire(), "foeName");
+
+        verify(techFighter).initSelfArming(anyString());
+        Assert.assertEquals("replaceMeWithExpectedResult", result);
+    }
+}
+
+//Generated with love by TestMe :) Please raise issues & feature requests at: https://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/verifyMethodCall/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/verifyMethodCall/test/com/example/services/impl/FooTest.java
@@ -37,7 +37,6 @@ public class FooTest {
         when(result.get()).thenReturn(Integer.valueOf(0));
 
         String result = foo.fight(new Fire(), "foeName");
-
         verify(techFighter).initSelfArming(anyString());
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }

--- a/testData/testMeGenerator/verifyMethodCall/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/verifyMethodCall/testGroovy/com/example/services/impl/FooTest.groovy
@@ -1,0 +1,42 @@
+package com.example.services.impl
+
+import com.example.beans.ConvertedBean
+import com.example.foes.Fire
+import com.example.warriers.TechFighter
+import org.junit.Test
+import org.junit.Before
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+
+import java.util.function.Supplier
+import static org.mockito.Mockito.*
+
+/** created by TestMe integration test on MMXVI */
+class FooTest {
+    @Mock
+    TechFighter techFighter
+    @Mock
+    Supplier<Integer> result
+    @InjectMocks
+    Foo foo
+
+    @Before
+    void setUp() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    @Test
+    void testFight() {
+        when(techFighter.fight(any())).thenReturn("fightResponse")
+        when(techFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean(myString: "myString", someNum: 0))
+        when(result.get()).thenReturn(0)
+
+        String result = foo.fight(new Fire(), "foeName")
+
+        verify(techFighter).initSelfArming(anyString())
+        assert result == "replaceMeWithExpectedResult"
+    }
+}
+
+//Generated with love by TestMe :) Please raise issues & feature requests at: https://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/verifyMethodCall/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/verifyMethodCall/testGroovy/com/example/services/impl/FooTest.groovy
@@ -33,7 +33,6 @@ class FooTest {
         when(result.get()).thenReturn(0)
 
         String result = foo.fight(new Fire(), "foeName")
-
         verify(techFighter).initSelfArming(anyString())
         assert result == "replaceMeWithExpectedResult"
     }

--- a/testData/testMeGenerator/verifyMethodCall/testJunit5/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/verifyMethodCall/testJunit5/com/example/services/impl/FooTest.java
@@ -37,7 +37,6 @@ class FooTest {
         when(result.get()).thenReturn(Integer.valueOf(0));
 
         String result = foo.fight(new Fire(), "foeName");
-
         verify(techFighter).initSelfArming(anyString());
         Assertions.assertEquals("replaceMeWithExpectedResult", result);
     }

--- a/testData/testMeGenerator/verifyMethodCall/testJunit5/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/verifyMethodCall/testJunit5/com/example/services/impl/FooTest.java
@@ -1,0 +1,46 @@
+package com.example.services.impl;
+
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fire;
+import com.example.warriers.TechFighter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * created by TestMe integration test on MMXVI
+ */
+class FooTest {
+    @Mock
+    TechFighter techFighter;
+    @Mock
+    Supplier<Integer> result;
+    @InjectMocks
+    Foo foo;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void testFight() {
+        when(techFighter.fight(any())).thenReturn("fightResponse");
+        when(techFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
+        when(result.get()).thenReturn(Integer.valueOf(0));
+
+        String result = foo.fight(new Fire(), "foeName");
+
+        verify(techFighter).initSelfArming(anyString());
+        Assertions.assertEquals("replaceMeWithExpectedResult", result);
+    }
+}
+
+//Generated with love by TestMe :) Please raise issues & feature requests at: https://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/verifyMethodCall/testTestNg/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/verifyMethodCall/testTestNg/com/example/services/impl/FooTest.java
@@ -1,0 +1,46 @@
+package com.example.services.impl;
+
+import com.example.beans.ConvertedBean;
+import com.example.foes.Fire;
+import com.example.warriers.TechFighter;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * created by TestMe integration test on MMXVI
+ */
+public class FooTest {
+    @Mock
+    TechFighter techFighter;
+    @Mock
+    Supplier<Integer> result;
+    @InjectMocks
+    Foo foo;
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testFight() {
+        when(techFighter.fight(any())).thenReturn("fightResponse");
+        when(techFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
+        when(result.get()).thenReturn(Integer.valueOf(0));
+
+        String result = foo.fight(new Fire(), "foeName");
+
+        verify(techFighter).initSelfArming(anyString());
+        Assert.assertEquals(result, "replaceMeWithExpectedResult");
+    }
+}
+
+//Generated with love by TestMe :) Please raise issues & feature requests at: https://weirddev.com/forum#!/testme

--- a/testData/testMeGenerator/verifyMethodCall/testTestNg/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/verifyMethodCall/testTestNg/com/example/services/impl/FooTest.java
@@ -37,7 +37,6 @@ public class FooTest {
         when(result.get()).thenReturn(Integer.valueOf(0));
 
         String result = foo.fight(new Fire(), "foeName");
-
         verify(techFighter).initSelfArming(anyString());
         Assert.assertEquals(result, "replaceMeWithExpectedResult");
     }


### PR DESCRIPTION
add verify for void return type of method calls，

for exemple
````java
public class Foo{

    private TechFighter techFighter;
    private Supplier<Integer> result;

    public String fight(Fire withFire,String foeName) {
        techFighter.initSelfArming("gun");
        String fail = techFighter.fight(withFire);
        ConvertedBean convertedBean = techFighter.surrender(new Fear(), new Ice(), 666);
        convertedBean.setSomeNum(result.get());
        return "returning response from dependency "+ fail + " " + convertedBean.getMyString();
    }
}
````
add the verify for `techFighter.initSelfArming` method calls like
````java
public class FooTest {
    @Mock
    TechFighter techFighter;
    @Mock
    Supplier<Integer> result;
    @InjectMocks
    Foo foo;

    @BeforeMethod
    public void setUp() {
        MockitoAnnotations.initMocks(this);
    }

    @Test
    public void testFight() {
        when(techFighter.fight(any())).thenReturn("fightResponse");
        when(techFighter.surrender(any(), any(), anyInt())).thenReturn(new ConvertedBean());
        when(result.get()).thenReturn(Integer.valueOf(0));

        String result = foo.fight(new Fire(), "foeName");
        verify(techFighter).initSelfArming(anyString());
        Assert.assertEquals(result, "replaceMeWithExpectedResult");
    }
}
````