### PR TITLE
Feature/do not mock inline init field

### DIFF
--- a/src/main/java/com/weirddev/testme/intellij/template/context/Field.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/Field.java
@@ -45,6 +45,10 @@ public class Field {
      * true if field has setter in tested class
      */
     @Getter private final boolean hasSetter;
+    /**
+     * true if field is set to a value on declaration
+     */
+    @Getter private final boolean isInitializedInline;
 
     /**
      * name given to field
@@ -61,6 +65,7 @@ public class Field {
         overridden = isOverriddenInChild(psiField, srcClass);
         isFinal = psiField.getModifierList() != null && psiField.getModifierList().hasExplicitModifier(PsiModifier.FINAL);
         isStatic = psiField.getModifierList() != null && psiField.getModifierList().hasExplicitModifier(PsiModifier.STATIC);
+        isInitializedInline = typeDictionary!=null && typeDictionary.isTestSubject(srcClass) && psiField.hasInitializer();//hasInitializer - expensive test - call only for test subject (consider moving to a new type - ExtendedField - for usage in test subject 
     }
 
     /**

--- a/src/main/java/com/weirddev/testme/intellij/template/context/PowerMockBuilder.java
+++ b/src/main/java/com/weirddev/testme/intellij/template/context/PowerMockBuilder.java
@@ -35,9 +35,7 @@ public class PowerMockBuilder extends MockitoMockBuilder{
      */
     @Override
     public boolean isMockable(Field field, Type testedClass) {
-        final boolean isMockable = !field.getType().isPrimitive() && !isWrapperType(field.getType())
-            && !field.isOverridden() && !field.getType().isArray() && !field.getType().isEnum()
-            && !testSubjectInspector.isNotInjectedInDiClass(field, testedClass);
+        final boolean isMockable = isMockableCommonChecks(field, testedClass);
         LOG.debug("field " + field.getType().getCanonicalName() + " " + field.getName() + " is mockable:" + isMockable);
         return isMockable;
     }

--- a/testData/testMeGenerator/mockReturned/src/com/example/services/impl/Foo.java
+++ b/testData/testMeGenerator/mockReturned/src/com/example/services/impl/Foo.java
@@ -12,7 +12,7 @@ public class Foo{
 
     private FooFighter fooFighter;
     private Supplier<Integer> result;
-    private Logger logger;
+    private Logger logger = Logger.getLogger(Foo.class.getName());;
 
     public String fight(Fire withFire,String foeName) {
         logger.trace("this method does not return a value so it should not be stubbed");

--- a/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
@@ -22,6 +22,7 @@ public class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
+
     @InjectMocks
     Foo foo;
 

--- a/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/test/com/example/services/impl/FooTest.java
@@ -1,7 +1,6 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
-import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.junit.Assert;
@@ -23,8 +22,6 @@ public class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
-    @Mock
-    Logger logger;
     @InjectMocks
     Foo foo;
 
@@ -39,7 +36,6 @@ public class FooTest {
         when(result.get()).thenReturn(Integer.valueOf(0));
 
         String result = foo.fight(new Fire(), "foeName");
-        verify(logger).trace(anyString());
         Assert.assertEquals("replaceMeWithExpectedResult", result);
     }
 }

--- a/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
@@ -20,6 +20,7 @@ class FooTest {
     FooFighter fooFighter
     @Mock
     Supplier<Integer> result
+
     @InjectMocks
     Foo foo
 

--- a/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testGroovy/com/example/services/impl/FooTest.groovy
@@ -1,7 +1,6 @@
 package com.example.services.impl
 
 import com.example.beans.ConvertedBean
-import com.example.dependencies.Logger
 import com.example.foes.Fear
 import com.example.foes.Fire
 import com.example.foes.Ice
@@ -21,8 +20,6 @@ class FooTest {
     FooFighter fooFighter
     @Mock
     Supplier<Integer> result
-    @Mock
-    Logger logger
     @InjectMocks
     Foo foo
 
@@ -37,7 +34,6 @@ class FooTest {
         when(result.get()).thenReturn(0)
 
         String result = foo.fight(new Fire(), "foeName")
-        verify(logger).trace(anyString())
         assert result == "replaceMeWithExpectedResult"
     }
 }

--- a/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
@@ -22,6 +22,7 @@ class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
+
     @InjectMocks
     Foo foo;
 

--- a/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testJunit5/com/example/services/impl/FooTest.java
@@ -1,7 +1,6 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
-import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.junit.jupiter.api.Assertions;
@@ -23,8 +22,6 @@ class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
-    @Mock
-    Logger logger;
     @InjectMocks
     Foo foo;
 
@@ -39,7 +36,6 @@ class FooTest {
         when(result.get()).thenReturn(Integer.valueOf(0));
 
         String result = foo.fight(new Fire(), "foeName");
-        verify(logger).trace(anyString());
         Assertions.assertEquals("replaceMeWithExpectedResult", result);
     }
 }

--- a/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
@@ -19,6 +19,7 @@ class FooTest extends Specification {
     FooFighter fooFighter
     @Mock
     Supplier<Integer> result
+
     @InjectMocks
     Foo foo
 

--- a/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
+++ b/testData/testMeGenerator/mockReturned/testSpock/com/example/services/impl/FooTest.groovy
@@ -1,7 +1,6 @@
 package com.example.services.impl
 
 import com.example.beans.ConvertedBean
-import com.example.dependencies.Logger
 import com.example.foes.Fear
 import com.example.foes.Fire
 import com.example.foes.Ice
@@ -20,8 +19,6 @@ class FooTest extends Specification {
     FooFighter fooFighter
     @Mock
     Supplier<Integer> result
-    @Mock
-    Logger logger
     @InjectMocks
     Foo foo
 

--- a/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
@@ -22,6 +22,7 @@ public class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
+
     @InjectMocks
     Foo foo;
 

--- a/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
+++ b/testData/testMeGenerator/mockReturned/testTestNg/com/example/services/impl/FooTest.java
@@ -1,7 +1,6 @@
 package com.example.services.impl;
 
 import com.example.beans.ConvertedBean;
-import com.example.dependencies.Logger;
 import com.example.foes.Fire;
 import com.example.warriers.FooFighter;
 import org.mockito.InjectMocks;
@@ -23,8 +22,6 @@ public class FooTest {
     FooFighter fooFighter;
     @Mock
     Supplier<Integer> result;
-    @Mock
-    Logger logger;
     @InjectMocks
     Foo foo;
 
@@ -39,7 +36,6 @@ public class FooTest {
         when(result.get()).thenReturn(Integer.valueOf(0));
 
         String result = foo.fight(new Fire(), "foeName");
-        verify(logger).trace(anyString());
         Assert.assertEquals(result, "replaceMeWithExpectedResult");
     }
 }


### PR DESCRIPTION
Avoid mocking field that is initialized inline and it's name matches typical logger naming patterns (to reduce impact since currently  field overrides in constructor and static initializer are not being searched for)