### PR TITLE
file template customization bug fix

### DIFF
--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4PowerMockTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4PowerMockTest.java
@@ -47,11 +47,8 @@ public class TestMeGeneratorJunit4PowerMockTest extends TestMeGeneratorTestBase 
         final TestMeConfig testMeConfig = new TestMeConfig();
         testMeConfig.setOpenCustomizeTestDialog(true);
         final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig(testMeConfig);
-        List<String> selectedFieldNameList = new ArrayList<>();
-        selectedFieldNameList.add("result");
-        selectedFieldNameList.add("techFighter");
-        List<String> selectedMethodIdList = new ArrayList<>();
-        selectedMethodIdList.add("com.example.services.impl.Foo#fight(com.example.foes.Fire,java.lang.String)");
+        List<String> selectedFieldNameList = List.of("result", "techFighter");
+        List<String> selectedMethodIdList = List.of("com.example.services.impl.Foo#fight(com.example.foes.Fire,java.lang.String)");
         final FileTemplateCustomization customization =
             new FileTemplateCustomization(selectedFieldNameList, selectedMethodIdList, true);
         doTest(fileTemplateConfig, customization);

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit4Test.java
@@ -200,11 +200,8 @@ public class TestMeGeneratorJunit4Test extends TestMeGeneratorTestBase{
         final TestMeConfig testMeConfig = new TestMeConfig();
         testMeConfig.setOpenCustomizeTestDialog(true);
         final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig(testMeConfig);
-        List<String> selectedFieldNameList = new ArrayList<>();
-        selectedFieldNameList.add("result");
-        selectedFieldNameList.add("techFighter");
-        List<String> selectedMethodIdList = new ArrayList<>();
-        selectedMethodIdList.add("com.example.services.impl.Foo#fight(com.example.foes.Fire,java.lang.String)");
+        List<String> selectedFieldNameList = List.of("result", "techFighter");
+        List<String> selectedMethodIdList = List.of("com.example.services.impl.Foo#fight(com.example.foes.Fire,java.lang.String)");
         final FileTemplateCustomization customization =
             new FileTemplateCustomization(selectedFieldNameList, selectedMethodIdList, true);
         doTest(fileTemplateConfig, customization);

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorJunit5Test.java
@@ -58,11 +58,8 @@ public class TestMeGeneratorJunit5Test extends TestMeGeneratorTestBase {
         final TestMeConfig testMeConfig = new TestMeConfig();
         testMeConfig.setOpenCustomizeTestDialog(true);
         final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig(testMeConfig);
-        List<String> selectedFieldNameList = new ArrayList<>();
-        selectedFieldNameList.add("result");
-        selectedFieldNameList.add("techFighter");
-        List<String> selectedMethodIdList = new ArrayList<>();
-        selectedMethodIdList.add("com.example.services.impl.Foo#fight(com.example.foes.Fire,java.lang.String)");
+        List<String> selectedFieldNameList = List.of("result", "techFighter");
+        List<String> selectedMethodIdList = List.of("com.example.services.impl.Foo#fight(com.example.foes.Fire,java.lang.String)");
         final FileTemplateCustomization customization =
             new FileTemplateCustomization(selectedFieldNameList, selectedMethodIdList, true);
         doTest(fileTemplateConfig, customization);

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorSpockTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorSpockTest.java
@@ -51,11 +51,8 @@ public class TestMeGeneratorSpockTest extends TestMeGeneratorTestBase {
         final TestMeConfig testMeConfig = new TestMeConfig();
         testMeConfig.setOpenCustomizeTestDialog(true);
         final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig(testMeConfig);
-        List<String> selectedFieldNameList = new ArrayList<>();
-        selectedFieldNameList.add("result");
-        selectedFieldNameList.add("techFighter");
-        List<String> selectedMethodIdList = new ArrayList<>();
-        selectedMethodIdList.add("com.example.services.impl.Foo#fight(com.example.foes.Fire,java.lang.String)");
+        List<String> selectedFieldNameList = List.of("result", "techFighter");
+        List<String> selectedMethodIdList = List.of("com.example.services.impl.Foo#fight(com.example.foes.Fire,java.lang.String)");
         final FileTemplateCustomization customization =
             new FileTemplateCustomization(selectedFieldNameList, selectedMethodIdList, true);
         doTest(fileTemplateConfig, customization);

--- a/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestNgTest.java
+++ b/src/integrationTest/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestNgTest.java
@@ -58,11 +58,8 @@ public class TestMeGeneratorTestNgTest extends TestMeGeneratorTestBase {
         final TestMeConfig testMeConfig = new TestMeConfig();
         testMeConfig.setOpenCustomizeTestDialog(true);
         final FileTemplateConfig fileTemplateConfig = new FileTemplateConfig(testMeConfig);
-        List<String> selectedFieldNameList = new ArrayList<>();
-        selectedFieldNameList.add("result");
-        selectedFieldNameList.add("techFighter");
-        List<String> selectedMethodIdList = new ArrayList<>();
-        selectedMethodIdList.add("com.example.services.impl.Foo#fight(com.example.foes.Fire,java.lang.String)");
+        List<String> selectedFieldNameList = List.of("result", "techFighter");
+        List<String> selectedMethodIdList = List.of("com.example.services.impl.Foo#fight(com.example.foes.Fire,java.lang.String)");
         final FileTemplateCustomization customization =
             new FileTemplateCustomization(selectedFieldNameList, selectedMethodIdList, true);
         doTest(fileTemplateConfig, customization);


### PR DESCRIPTION
fix a NullPointerException, if a field is primitive`PsiUtil.resolveClassInType(psiField.getType())` returns null and cause NullPointerException
````
java.lang.NullPointerException: Cannot invoke "String.endsWith(String)" because "canonicalName" is null
	at com.weirddev.testme.intellij.utils.ClassNameUtils.isArray(ClassNameUtils.java:18)
	at com.weirddev.testme.intellij.ui.customizedialog.CustomizeTestDialog.isMockable(CustomizeTestDialog.java:164)
	at com.weirddev.testme.intellij.ui.customizedialog.CustomizeTestDialog.lambda$initFieldsTable$3(CustomizeTestDialog.java:131)
	at com.intellij.refactoring.util.classMembers.MemberInfo.extractClassMembers(MemberInfo.java:115)
	at com.weirddev.testme.intellij.ui.customizedialog.CustomizeTestDialog.initFieldsTable(CustomizeTestDialog.java:128)
	at com.weirddev.testme.intellij.ui.customizedialog.CustomizeTestDialog.<init>(CustomizeTestDialog.java:46)
	at com.weirddev.testme.intellij.action.CreateTestMeAction.createTestMeDialog(CreateTestMeAction.java:145)
	at com.weirddev.testme.intellij.action.CreateTestMeAction.invoke(CreateTestMeAction.java:125)
	at com.weirddev.testme.intellij.action.TestMeCreator.invoke(TestMeCreator.java:35)
	at com.weirddev.testme.intellij.action.TestMeCreator.createTest(TestMeCreator.java:25)
	at com.weirddev.testme.intellij.action.TestMeAdditionalAction.execute(TestMeAdditionalAction.java:49)
	at com.weirddev.testme.intellij.ui.popup.TestMePopUpHandler.lambda$show$1(TestMePopUpHandler.java:99)
	at com.intellij.openapi.ui.popup.PopupChooserBuilder.lambda$setItemChosenCallback$0(PopupChooserBuilder.java:207)
	at com.intellij.ui.popup.AbstractPopup.lambda$dispose$18(AbstractPopup.java:1636)
	at com.intellij.openapi.wm.impl.FocusManagerImpl.lambda$doWhenFocusSettlesDown$3(FocusManagerImpl.java:173)
	at com.intellij.util.ui.EdtInvocationManager.invokeLaterIfNeeded(EdtInvocationManager.java:33)
	at com.intellij.ide.IdeEventQueue.ifFocusEventsInTheQueue(IdeEventQueue.kt:210)
	at com.intellij.ide.IdeEventQueue.executeWhenAllFocusEventsLeftTheQueue(IdeEventQueue.kt:176)
	at com.intellij.openapi.wm.impl.FocusManagerImpl.doWhenFocusSettlesDown(FocusManagerImpl.java:169)
	at com.intellij.openapi.wm.impl.FocusManagerImpl.doWhenFocusSettlesDown(FocusManagerImpl.java:163)
	at com.intellij.ui.popup.AbstractPopup.dispose(AbstractPopup.java:1634)
	at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:129)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:161)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:262)
	at com.intellij.ui.popup.AbstractPopup.cancel(AbstractPopup.java:892)
	at com.intellij.ui.popup.AbstractPopup.closeOk(AbstractPopup.java:827)
	at com.intellij.openapi.ui.popup.PopupChooserBuilder.closePopup(PopupChooserBuilder.java:501)
	at com.intellij.openapi.ui.popup.PopupChooserBuilder$1.mouseReleased(PopupChooserBuilder.java:355)
	at java.desktop/java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:298)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6657)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3385)
	at java.desktop/java.awt.Component.processEvent(Component.java:6422)
	at java.desktop/java.awt.Container.processEvent(Container.java:2266)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5027)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4855)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4954)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4581)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4522)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2808)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4855)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:791)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:740)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:734)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:97)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:764)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:762)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:761)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:685)
	at com.intellij.ide.IdeEventQueue.dispatchMouseEvent(IdeEventQueue.kt:633)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:588)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:67)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:369)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:368)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:787)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:368)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:363)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:992)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:113)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:992)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$7(IdeEventQueue.kt:363)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:405)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
````