### PR TITLE
Gradle intellij platform v2.* build migration CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        IDEA_VERSION: [ 2023.2, 2024.1, LATEST-EAP-SNAPSHOT ]
-        WITH_IDEA_PLUGINS: [ true, false ]
         include:
           - IDEA_VERSION: 2023.2
             SCALA_PLUGIN_VERSION: 2023.2.23
@@ -24,9 +22,9 @@ jobs:
           - IDEA_VERSION: 2024.1
             SCALA_PLUGIN_VERSION: 2024.1.1
             WITH_IDEA_PLUGINS: true
-          - IDEA_VERSION: 2024.1
-            SCALA_PLUGIN_VERSION: 2024.1.1
-            WITH_IDEA_PLUGINS: false
+          - IDEA_VERSION: 2024.2.1
+            SCALA_PLUGIN_VERSION: 2024.2.1
+            WITH_IDEA_PLUGINS: true
           - IDEA_VERSION: LATEST-EAP-SNAPSHOT
             SCALA_PLUGIN_VERSION: 2024.2.1
             WITH_IDEA_PLUGINS: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,8 @@ jobs:
 #        uses: gradle/gradle-build-action@v2
 #        with:
         run: |
-          ./gradlew check jacocoTestReport jacocoIntTestReport -PideaVersion=${{ inputs.IDEA_VERSION }} -PscalaPluginVersion=${{ inputs.SCALA_PLUGIN_VERSION }} -PenableIdeaGroovyPlugin=${{ inputs.WITH_IDEA_PLUGINS }} -PenableIdeaScalaPlugin=${{ inputs.WITH_IDEA_PLUGINS }}
+#          ./gradlew check jacocoTestReport jacocoIntTestReport -PideaVersion=${{ inputs.IDEA_VERSION }} -PscalaPluginVersion=${{ inputs.SCALA_PLUGIN_VERSION }} -PenableIdeaGroovyPlugin=${{ inputs.WITH_IDEA_PLUGINS }} -PenableIdeaScalaPlugin=${{ inputs.WITH_IDEA_PLUGINS }}
+          ./gradlew check jacocoTestReport -PideaVersion=${{ inputs.IDEA_VERSION }} -PscalaPluginVersion=${{ inputs.SCALA_PLUGIN_VERSION }} -PenableIdeaGroovyPlugin=${{ inputs.WITH_IDEA_PLUGINS }} -PenableIdeaScalaPlugin=${{ inputs.WITH_IDEA_PLUGINS }}
 
       - name: Test Report
         uses: dorny/test-reporter@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,8 @@ jobs:
 #        uses: gradle/gradle-build-action@v2
 #        with:
         run: |
-#          ./gradlew check jacocoTestReport jacocoIntTestReport -PideaVersion=${{ inputs.IDEA_VERSION }} -PscalaPluginVersion=${{ inputs.SCALA_PLUGIN_VERSION }} -PenableIdeaGroovyPlugin=${{ inputs.WITH_IDEA_PLUGINS }} -PenableIdeaScalaPlugin=${{ inputs.WITH_IDEA_PLUGINS }}
           ./gradlew check jacocoTestReport -PideaVersion=${{ inputs.IDEA_VERSION }} -PscalaPluginVersion=${{ inputs.SCALA_PLUGIN_VERSION }} -PenableIdeaGroovyPlugin=${{ inputs.WITH_IDEA_PLUGINS }} -PenableIdeaScalaPlugin=${{ inputs.WITH_IDEA_PLUGINS }}
+#          ./gradlew check jacocoTestReport jacocoIntTestReport -PideaVersion=${{ inputs.IDEA_VERSION }} -PscalaPluginVersion=${{ inputs.SCALA_PLUGIN_VERSION }} -PenableIdeaGroovyPlugin=${{ inputs.WITH_IDEA_PLUGINS }} -PenableIdeaScalaPlugin=${{ inputs.WITH_IDEA_PLUGINS }}
 
       - name: Test Report
         uses: dorny/test-reporter@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           reporter: java-junit
 
       - name: Test Results artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test results ${{inputs.IDEA_VERSION}} plugins=${{inputs.WITH_IDEA_PLUGINS}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         continue-on-error: true
         with:
           name: Test Results (${{inputs.IDEA_VERSION}},${{inputs.WITH_IDEA_PLUGINS}})
-          path: build/test-results/**/*.xml
+          path: '**/build/test-results/**/*.xml'
           reporter: java-junit
 
       - name: Test Results artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
           
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
-        if: github.event.pull_request.head.repo.fork == false
+        if: ${{ github.event.pull_request.head.repo.fork == false && inputs.WITH_IDEA_PLUGINS == 'true' }}
         with:
 #          files: ./coverage1.xml,./coverage2.xml # optional
 #          flags: unittests # optional

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ hs_err_pid*
 classes
 out
 lombok.config
+/.intellijPlatform/

--- a/.run/check.run.xml
+++ b/.run/check.run.xml
@@ -18,7 +18,7 @@
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
-    <RunAsTest>false</RunAsTest>
+    <RunAsTest>true</RunAsTest>
     <method v="2" />
   </configuration>
 </component>

--- a/.run/check.run.xml
+++ b/.run/check.run.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="" />
+      <option name="scriptParameters" value="--rerun-tasks" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ println "***********************************************************************
 println "              Running build for ideaVersion: $ideaVersion and scalaPluginVersion: $scalaPluginVersion with Groovy plugin ${groovyOn} and Scala plugin ${scalaOn}"
 println "*****************************************************************************************************************************************************************"
 def isRunInCI=Boolean.valueOf(System.getenv('CI'))
-def testedProjects = subprojects + rootProject
+
 repositories {
     mavenCentral()
     intellijPlatform {
@@ -85,6 +85,7 @@ allprojects {
             includeNoLocationClasses = true
             excludes = ["jdk.internal.*"]
         }
+        useJUnitPlatform()
     }
 }
 
@@ -130,37 +131,44 @@ dependencies {
 //                "TemplateWordInPluginId,ForbiddenPluginIdPrefix"
 //        )
 //    }
-        testFramework(TestFrameworkType.Platform.INSTANCE)
+//        testFramework(TestFrameworkType.Platform.INSTANCE)
+        testFramework(TestFrameworkType.JUnit5.INSTANCE)
         testFramework(TestFrameworkType.Plugin.Java.INSTANCE)
+        pluginModule(implementation(project(':testme-intellij-common')))
+        pluginModule(implementation(project(':testme-intellij-groovy')))
+        pluginModule(implementation(project(':testme-intellij-scala')))
     }
 
-    testImplementation 'junit:junit:4.13.2'
-    implementation(project(':testme-intellij-common')) {
-        exclude group: 'com.jetbrains', module: 'ideaIC'
-        exclude group: 'org.jetbrains.plugins', module: 'junit'
-        exclude group: 'org.jetbrains.plugins', module: 'properties'
-        exclude group: 'org.jetbrains.plugins', module: 'Groovy'
-    }
-    implementation(project(':testme-intellij-groovy')) {
-        exclude group: 'com.jetbrains', module: 'ideaIC'
-        exclude group: 'org.jetbrains.plugins', module: 'junit'
-        exclude group: 'org.jetbrains.plugins', module: 'properties'
-        exclude group: 'org.jetbrains.plugins', module: 'Groovy'
-    }
-    implementation(project(':testme-intellij-scala')) {
-        exclude group: 'com.jetbrains', module: 'ideaIC'
-        exclude group: 'org.jetbrains.plugins', module: 'junit'
-        exclude group: 'org.jetbrains.plugins', module: 'properties'
-        exclude group: 'org.jetbrains.plugins', module: 'Groovy'
-        exclude group: 'org.jetbrains.plugins', module: 'Scala'
-    }
-
+//    implementation(project(':testme-intellij-common')) {
+//        exclude group: 'com.jetbrains', module: 'ideaIC'
+//        exclude group: 'org.jetbrains.plugins', module: 'junit'
+//        exclude group: 'org.jetbrains.plugins', module: 'properties'
+//        exclude group: 'org.jetbrains.plugins', module: 'Groovy'
+//    }
+//    implementation(project(':testme-intellij-groovy')) {
+//        exclude group: 'com.jetbrains', module: 'ideaIC'
+//        exclude group: 'org.jetbrains.plugins', module: 'junit'
+//        exclude group: 'org.jetbrains.plugins', module: 'properties'
+//        exclude group: 'org.jetbrains.plugins', module: 'Groovy'
+//    }
+//    implementation(project(':testme-intellij-scala')) {
+//        exclude group: 'com.jetbrains', module: 'ideaIC'
+//        exclude group: 'org.jetbrains.plugins', module: 'junit'
+//        exclude group: 'org.jetbrains.plugins', module: 'properties'
+//        exclude group: 'org.jetbrains.plugins', module: 'Groovy'
+//        exclude group: 'org.jetbrains.plugins', module: 'Scala'
+//    }
+//
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
+    testCompileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.11.12'
     testImplementation 'org.mockito:mockito-core:4.3.1'
     testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
-    testCompileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.11.12'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
+    testImplementation 'junit:junit:4.13.2'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
 
 def javadocHeader = ""

--- a/build.gradle
+++ b/build.gradle
@@ -20,20 +20,33 @@ def scalaOn = enableIdeaScalaPlugin ? 'enabled':'disabled'
 println "*****************************************************************************************************************************************************************"
 println "              Running build for ideaVersion: $ideaVersion and scalaPluginVersion: $scalaPluginVersion with Groovy plugin ${groovyOn} and Scala plugin ${scalaOn}"
 println "*****************************************************************************************************************************************************************"
-def isRunInCI=Boolean.valueOf(System.getenv('CI'))
 
+def isRunInCI=Boolean.valueOf(System.getenv('CI'))
+def turnOffPlugins = []
+if (!enableIdeaScalaPlugin) {
+    turnOffPlugins += "org.intellij.scala"
+}
+if (!enableIdeaGroovyPlugin) {
+    turnOffPlugins += "org.intellij.groovy"
+}
 repositories {
     mavenCentral()
     intellijPlatform {
         defaultRepositories()
+        jetbrainsRuntime()
     }
 }
 dependencies {
     intellijPlatform {
-        create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"))
+        create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion")/*, useInstaller = false*/)
+        jetbrainsRuntime()
         bundledPlugins(["org.intellij.groovy"])
         plugins(["org.intellij.scala:" + scalaPluginVersion])
         instrumentationTools()
+        prepareTestSandbox {
+            disabledPlugins = turnOffPlugins
+        }
+
 //        pluginVerifier()
 //        zipSigner()
 //    pluginVerification {
@@ -79,27 +92,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
-def disabledPlugins = []
-if (!enableIdeaScalaPlugin) {
-    disabledPlugins += "org.intellij.scala"
-}
-if (!enableIdeaGroovyPlugin) {
-    disabledPlugins += "org.intellij.groovy"
-}
-intellijPlatformTesting.testIde {
-    testCustomSetup {
-        plugins  {
-            println "disablePlugins: "+disabledPlugins
-            disablePlugins(disabledPlugins)
-        }
-    }
-}
-//tasks.test.configure {
-//    actions +=  tasks.named('testCustomSetup').get().actions
-//    actions.clear()
-//    dependsOn('testCustomSetup')
-//}
-//tasks.named('testCustomSetup', Test) {
 def shouldInstrumentCode = !Boolean.valueOf(System.getProperty('skipCodeInstrumentation', 'false'))
 intellijPlatform {
     projectName = 'TestMe'
@@ -163,7 +155,6 @@ allprojects {
 }
 
 test {
-    actions +=  tasks.named('testCustomSetup').get().actions
     afterTest { desc, result ->
         println "Executing test [${desc.className}].${desc.name} with result: ${result.resultType}"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
-    testImplementation 'org.mockito:mockito-core:4.3.1'
+    testImplementation 'org.mockito:mockito-core:5.13.0'
     testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
     testImplementation 'junit:junit:4.13.2'

--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,10 @@ intellijPlatformTesting.testIde {
         }
     }
 }
-
+tasks.test.configure {
+    actions.clear()
+    dependsOn('testCustomSetup')
+}
 //tasks.register('jacocoRootReport', JacocoReport) {
 //    description = 'Generates an aggregate report from all subprojects'
 //    dependsOn check, jacocoMerge

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,8 @@ plugins {
     id("org.jetbrains.intellij.platform") version "2.0.1"
 }
 
-//apply plugin: 'jacoco'
-//apply plugin: "org.jetbrains.intellij.platform"
-apply plugin: 'java'
 apply plugin: 'groovy'
+apply plugin: 'java'
 
 def enableIdeaGroovyPlugin=Boolean.valueOf(enableIdeaGroovyPlugin)
 def groovyOn = enableIdeaGroovyPlugin ? 'enabled':'disabled'
@@ -88,7 +86,18 @@ allprojects {
         useJUnitPlatform()
     }
 }
-
+jacocoTestReport {
+    dependsOn test
+    classDirectories.setFrom(instrumentCode)
+    reports {
+        xml.required = true
+        html.required = !isRunInCI
+    }
+    classDirectories.from = files(classDirectories.files.collect {
+        fileTree(dir: it, exclude: 'com/weirddev/testme/intellij/ui/**')
+    })
+    outputs.upToDateWhen { false } // Always generate report
+}
 def shouldInstrumentCode = !Boolean.valueOf(System.getProperty('skipCodeInstrumentation', 'false'))
 intellijPlatform {
     projectName = 'TestMe'
@@ -168,7 +177,23 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
-
+//tasks.register('jacocoRootReport', JacocoReport) {
+//    description = 'Generates an aggregate report from all subprojects'
+//    dependsOn check, jacocoMerge
+//    additionalSourceDirs.from = files(testedProjects.sourceSets.main.allSource.srcDirs)
+//    sourceDirectories.from = files(testedProjects.sourceSets.main.allSource.srcDirs)
+////    classDirectories.from = files(testedProjects.sourceSets.main.output)
+////    classDirectories.setFrom(instrumentCode)
+//    classDirectories.setFrom(testedProjects.collect { it.instrumentCode })
+//    //https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#jacoco-reports-0-coverage
+////     executionData files(testedProjects*.tasks.withType(Test).executionData)
+//    executionData jacocoMerge.destinationFile
+//    reports {
+//        xml.enabled true //isRunInCI
+//        html.enabled !isRunInCI
+//        html.destination file("${buildDir}/jacocoHtml")
+//    }
+//}
 def javadocHeader = ""
 task templateContextJavadocs(type: Javadoc, description: 'Generate javadocs for template context', group: 'Documentation') {
     dependsOn delombok

--- a/build.gradle
+++ b/build.gradle
@@ -28,84 +28,6 @@ repositories {
         defaultRepositories()
     }
 }
-
-allprojects {
-    sourceCompatibility = jvmTargetVersion
-    targetCompatibility = jvmTargetVersion
-    repositories {
-        mavenCentral()
-    }
-    jacoco {
-        toolVersion = "0.8.11"
-    }
-
-    tasks.withType(JavaCompile) {
-        options.encoding = 'UTF-8'
-        if (!javaHome) {
-            println "javaHome var not set. setting java home from JAVA_HOME env var"
-            javaHome = System.getenv().JAVA_HOME //            javaHome =  'C:\\Program Files\\AdoptOpenJDK\\jdk-13.0.2.8-hotspot'
-        }
-        println "JAVA_HOME=$javaHome"
-    }
-    testSets {
-        integrationTest
-    }
-    integrationTest {
-        afterTest { desc, result ->
-            println "Executing test [${desc.className}].${desc.name} with result: ${result.resultType}"
-        }
-        reports.html.required = !isRunInCI
-//        exclude '**/TestMeGenerator*'  //temp exclude. for shortening build time when testing build changes
-//        include '**/utils/TestSubjectResolverUtilsTest.class'  //temp exclude
-        jacoco {
-            includeNoLocationClasses = true
-            excludes = ["jdk.internal.*"]
-        }
-    }
-    tasks.withType(Test) {
-        systemProperty 'java.awt.headless', 'true'
-        systemProperty 'enableIdeaGroovyPlugin', enableIdeaGroovyPlugin
-        systemProperty 'enableIdeaScalaPlugin', enableIdeaScalaPlugin
-        reports.html.destination = file("${reporting.baseDir}/${name}")
-        testLogging {
-            exceptionFormat = TestExceptionFormat.FULL
-//            events TestLogEvent.FAILED, TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR
-            events TestLogEvent.values()
-            showStandardStreams = true
-        }
-    }
-}
-
-jacocoTestReport {
-    dependsOn test
-    classDirectories.setFrom(instrumentCode)
-    reports {
-        xml.required = true
-        html.required = !isRunInCI
-    }
-    classDirectories.from = files(classDirectories.files.collect {
-        fileTree(dir: it, exclude: 'com/weirddev/testme/intellij/ui/**')
-    })
-    outputs.upToDateWhen { false } // Always generate report
-}
-def shouldInstrumentCode = !Boolean.valueOf(System.getProperty('skipCodeInstrumentation', 'false'))
-intellijPlatform {
-    projectName = 'TestMe'
-    instrumentCode = shouldInstrumentCode
-    pluginConfiguration {
-        id = group
-        name = 'TestMe'
-        version = testMeVersion
-        ideaVersion {
-            sinceBuild = '232'
-//           untilBuild = '242.*'
-        }
-    }
-    publishing {
-        token = System.getenv("ORG_GRADLE_PROJECT_intellijPublishToken")
-        channels = [ideaPublishChannel]
-    }
-}
 dependencies {
     intellijPlatform {
         create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"))
@@ -157,7 +79,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
-
 def disabledPlugins = []
 if (!enableIdeaScalaPlugin) {
     disabledPlugins += "org.intellij.scala"
@@ -173,11 +94,76 @@ intellijPlatformTesting.testIde {
         }
     }
 }
-tasks.test.configure {
-    actions.clear()
-    dependsOn('testCustomSetup')
+//tasks.test.configure {
+//    actions +=  tasks.named('testCustomSetup').get().actions
+//    actions.clear()
+//    dependsOn('testCustomSetup')
+//}
+//tasks.named('testCustomSetup', Test) {
+def shouldInstrumentCode = !Boolean.valueOf(System.getProperty('skipCodeInstrumentation', 'false'))
+intellijPlatform {
+    projectName = 'TestMe'
+    instrumentCode = shouldInstrumentCode
+    pluginConfiguration {
+        id = group
+        name = 'TestMe'
+        version = testMeVersion
+        ideaVersion {
+            sinceBuild = '232'
+//           untilBuild = '242.*'
+        }
+    }
+    publishing {
+        token = System.getenv("ORG_GRADLE_PROJECT_intellijPublishToken")
+        channels = [ideaPublishChannel]
+    }
 }
-tasks.named('testCustomSetup', Test) {
+
+allprojects {
+    sourceCompatibility = jvmTargetVersion
+    targetCompatibility = jvmTargetVersion
+    jacoco {
+        toolVersion = "0.8.11"
+    }
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
+        if (!javaHome) {
+            println "javaHome var not set. setting java home from JAVA_HOME env var"
+            javaHome = System.getenv().JAVA_HOME //            javaHome =  'C:\\Program Files\\AdoptOpenJDK\\jdk-13.0.2.8-hotspot'
+        }
+        println "JAVA_HOME=$javaHome"
+    }
+    testSets {
+        integrationTest
+    }
+    integrationTest {
+        afterTest { desc, result ->
+            println "Executing test [${desc.className}].${desc.name} with result: ${result.resultType}"
+        }
+        reports.html.required = !isRunInCI
+//        exclude '**/TestMeGenerator*'  //temp exclude. for shortening build time when testing build changes
+//        include '**/utils/TestSubjectResolverUtilsTest.class'  //temp exclude
+        jacoco {
+            includeNoLocationClasses = true
+            excludes = ["jdk.internal.*"]
+        }
+    }
+    tasks.withType(Test) {
+        systemProperty 'java.awt.headless', 'true'
+        systemProperty 'enableIdeaGroovyPlugin', enableIdeaGroovyPlugin
+        systemProperty 'enableIdeaScalaPlugin', enableIdeaScalaPlugin
+        reports.html.destination = file("${reporting.baseDir}/${name}")
+        testLogging {
+            exceptionFormat = TestExceptionFormat.FULL
+//            events TestLogEvent.FAILED, TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR
+            events TestLogEvent.values()
+            showStandardStreams = true
+        }
+    }
+}
+
+test {
+    actions +=  tasks.named('testCustomSetup').get().actions
     afterTest { desc, result ->
         println "Executing test [${desc.className}].${desc.name} with result: ${result.resultType}"
     }
@@ -188,6 +174,19 @@ tasks.named('testCustomSetup', Test) {
     }
     useJUnitPlatform()
 }
+jacocoTestReport {
+    dependsOn test
+    classDirectories.setFrom(instrumentCode)
+    reports {
+        xml.required = true
+        html.required = !isRunInCI
+    }
+    classDirectories.from = files(classDirectories.files.collect {
+        fileTree(dir: it, exclude: 'com/weirddev/testme/intellij/ui/**')
+    })
+    outputs.upToDateWhen { false } // Always generate report
+}
+
 
 //tasks.register('jacocoRootReport', JacocoReport) {
 //    description = 'Generates an aggregate report from all subprojects'

--- a/build.gradle
+++ b/build.gradle
@@ -74,18 +74,8 @@ allprojects {
             showStandardStreams = true
         }
     }
-    test {
-        afterTest { desc, result ->
-            println "Executing test [${desc.className}].${desc.name} with result: ${result.resultType}"
-        }
-        reports.html.required = !isRunInCI
-        jacoco {
-            includeNoLocationClasses = true
-            excludes = ["jdk.internal.*"]
-        }
-        useJUnitPlatform()
-    }
 }
+
 jacocoTestReport {
     dependsOn test
     classDirectories.setFrom(instrumentCode)
@@ -187,6 +177,18 @@ tasks.test.configure {
     actions.clear()
     dependsOn('testCustomSetup')
 }
+tasks.named('testCustomSetup', Test) {
+    afterTest { desc, result ->
+        println "Executing test [${desc.className}].${desc.name} with result: ${result.resultType}"
+    }
+    reports.html.required = !isRunInCI
+    jacoco {
+        includeNoLocationClasses = true
+        excludes = ["jdk.internal.*"]
+    }
+    useJUnitPlatform()
+}
+
 //tasks.register('jacocoRootReport', JacocoReport) {
 //    description = 'Generates an aggregate report from all subprojects'
 //    dependsOn check, jacocoMerge

--- a/build.gradle
+++ b/build.gradle
@@ -116,21 +116,11 @@ intellijPlatform {
         channels = [ideaPublishChannel]
     }
 }
-
-def enabledBundledPlugins = ["com.intellij.java"]
-if (enableIdeaGroovyPlugin) {
-    enabledBundledPlugins += "org.intellij.groovy"
-}
-def otherPlugins = []
-if (enableIdeaScalaPlugin) {
-    otherPlugins += ("org.intellij.scala:" + scalaPluginVersion)
-}
 dependencies {
     intellijPlatform {
         create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"))
-        bundledPlugins(enabledBundledPlugins)
-        plugins(otherPlugins)
-
+        bundledPlugins(["org.intellij.groovy"])
+        plugins(["org.intellij.scala:" + scalaPluginVersion])
         instrumentationTools()
 //        pluginVerifier()
 //        zipSigner()
@@ -177,6 +167,23 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
+
+def disabledPlugins = []
+if (!enableIdeaScalaPlugin) {
+    disabledPlugins += "org.intellij.scala"
+}
+if (!enableIdeaGroovyPlugin) {
+    disabledPlugins += "org.intellij.groovy"
+}
+intellijPlatformTesting.testIde {
+    testCustomSetup {
+        plugins  {
+            println "disablePlugins: "+disabledPlugins
+            disablePlugins(disabledPlugins)
+        }
+    }
+}
+
 //tasks.register('jacocoRootReport', JacocoReport) {
 //    description = 'Generates an aggregate report from all subprojects'
 //    dependsOn check, jacocoMerge

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,12 @@ plugins {
     id 'org.unbroken-dome.test-sets' version '4.1.0'
     id "io.freefair.lombok" version "8.3"
     id("org.jetbrains.intellij.platform") version "2.0.1"
-    id("org.jetbrains.intellij.platform.migration") version "2.0.1"
 }
 
-apply plugin: 'jacoco'
-apply plugin: "org.jetbrains.intellij.platform"
+//apply plugin: 'jacoco'
+//apply plugin: "org.jetbrains.intellij.platform"
+apply plugin: 'java'
+apply plugin: 'groovy'
 
 def enableIdeaGroovyPlugin=Boolean.valueOf(enableIdeaGroovyPlugin)
 def groovyOn = enableIdeaGroovyPlugin ? 'enabled':'disabled'
@@ -106,7 +107,6 @@ intellijPlatform {
     }
 }
 
-def spockVersion = "1.0-groovy-2.4"
 def enabledBundledPlugins = ["com.intellij.java"]
 if (enableIdeaGroovyPlugin) {
     enabledBundledPlugins += "org.intellij.groovy"
@@ -120,9 +120,16 @@ dependencies {
         create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"))
         bundledPlugins(enabledBundledPlugins)
         plugins(otherPlugins)
+
         instrumentationTools()
-        pluginVerifier()
-        zipSigner()
+//        pluginVerifier()
+//        zipSigner()
+//    pluginVerification {
+//        freeArgs = listOf(
+//                "-mute",
+//                "TemplateWordInPluginId,ForbiddenPluginIdPrefix"
+//        )
+//    }
         testFramework(TestFrameworkType.Platform.INSTANCE)
         testFramework(TestFrameworkType.Plugin.Java.INSTANCE)
     }
@@ -152,10 +159,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
     testImplementation 'org.mockito:mockito-core:4.3.1'
-    testImplementation("org.spockframework:spock-core:$spockVersion") {
-//        exclude group: 'org.codehaus.groovy'
-    }
-    testImplementation 'org.opentest4j:opentest4j:1.3.0'
+    testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
     testCompileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.11.12'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
-//import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 
 plugins {
     id 'jacoco'
@@ -51,16 +51,7 @@ dependencies {
         prepareTestSandbox {
             disabledPlugins = turnOffPlugins
         }
-
-//        pluginVerifier()
-//        zipSigner()
-//    pluginVerification {
-//        freeArgs = listOf(
-//                "-mute",
-//                "TemplateWordInPluginId,ForbiddenPluginIdPrefix"
-//        )
-//    }
-//        testFramework(TestFrameworkType.Platform.INSTANCE)
+        pluginVerifier()
         testFramework(TestFrameworkType.JUnit5.INSTANCE)
         testFramework(TestFrameworkType.Plugin.Java.INSTANCE)
         pluginModule(implementation(project(':testme-intellij-common')))
@@ -68,26 +59,6 @@ dependencies {
         pluginModule(implementation(project(':testme-intellij-scala')))
     }
 
-//    implementation(project(':testme-intellij-common')) {
-//        exclude group: 'com.jetbrains', module: 'ideaIC'
-//        exclude group: 'org.jetbrains.plugins', module: 'junit'
-//        exclude group: 'org.jetbrains.plugins', module: 'properties'
-//        exclude group: 'org.jetbrains.plugins', module: 'Groovy'
-//    }
-//    implementation(project(':testme-intellij-groovy')) {
-//        exclude group: 'com.jetbrains', module: 'ideaIC'
-//        exclude group: 'org.jetbrains.plugins', module: 'junit'
-//        exclude group: 'org.jetbrains.plugins', module: 'properties'
-//        exclude group: 'org.jetbrains.plugins', module: 'Groovy'
-//    }
-//    implementation(project(':testme-intellij-scala')) {
-//        exclude group: 'com.jetbrains', module: 'ideaIC'
-//        exclude group: 'org.jetbrains.plugins', module: 'junit'
-//        exclude group: 'org.jetbrains.plugins', module: 'properties'
-//        exclude group: 'org.jetbrains.plugins', module: 'Groovy'
-//        exclude group: 'org.jetbrains.plugins', module: 'Scala'
-//    }
-//
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
@@ -113,6 +84,17 @@ intellijPlatform {
     publishing {
         token = System.getenv("ORG_GRADLE_PROJECT_intellijPublishToken")
         channels = [ideaPublishChannel]
+    }
+    pluginVerification {
+        ides {
+            recommended()
+//            ide IntelliJPlatformType.IntellijIdeaUltimate, "2023.3"
+//            ide IntelliJPlatformType.IntellijIdeaCommunity, "2024.2"
+        }
+//            freeArgs = listOf(
+//                "-mute",
+//                "TemplateWordInPluginId,ForbiddenPluginIdPrefix"
+//            )
     }
 }
 
@@ -183,7 +165,6 @@ jacocoTestReport {
     outputs.upToDateWhen { false } // Always generate report
 }
 
-
 //tasks.register('jacocoRootReport', JacocoReport) {
 //    description = 'Generates an aggregate report from all subprojects'
 //    dependsOn check, jacocoMerge
@@ -201,6 +182,7 @@ jacocoTestReport {
 //        html.destination file("${buildDir}/jacocoHtml")
 //    }
 //}
+
 def javadocHeader = ""
 task templateContextJavadocs(type: Javadoc, description: 'Generate javadocs for template context', group: 'Documentation') {
     dependsOn delombok

--- a/build.gradle
+++ b/build.gradle
@@ -162,10 +162,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
-    testCompileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.11.12'
     testImplementation 'org.mockito:mockito-core:4.3.1'
     testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
-
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
     testImplementation 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+//import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 
 plugins {
     id 'jacoco'
@@ -29,16 +30,20 @@ if (!enableIdeaScalaPlugin) {
 if (!enableIdeaGroovyPlugin) {
     turnOffPlugins += "org.intellij.groovy"
 }
+ext {
+    useInstaller = ideaVersion != 'LATEST-EAP-SNAPSHOT' //EAP versions are not bundled with OS installer. for other versions better use bundled OS installer as it's more like production environment
+}
 repositories {
     mavenCentral()
     intellijPlatform {
         defaultRepositories()
         jetbrainsRuntime()
+        snapshots()
     }
 }
 dependencies {
     intellijPlatform {
-        create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion")/*, useInstaller = false*/)
+        create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"), useInstaller)
         jetbrainsRuntime()
         bundledPlugins(["org.intellij.groovy"])
         plugins(["org.intellij.scala:" + scalaPluginVersion])

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,17 +7,19 @@ jvmTargetVersion = 17
 
 #If JAVA_HOME env var does not point to JDK 6 installation dir - run gradle while with systems/env var - javaHome
 javaHome=
-enableIdeaGroovyPlugin = true
-enableIdeaScalaPlugin = true
 org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8 -Dkotlin.daemon.jvm.options=--illegal-access=permit -Djava.awt.headless=true
+#org.gradle.unsafe.configuration-cache = true
+
 #Supported versions:
 #ideaVersion = 2024.2.1
- ideaVersion = 2023.2
+ideaType = IC
+ideaVersion = 2023.2
 #ideaVersion = LATEST-EAP-SNAPSHOT
 #ideaVersion = 233.11799-EAP-CANDIDATE-SNAPSHOT
-#scalaPluginVersion = 2024.2.1
-scalaPluginVersion = 2023.2.23
-ideaType = IC
-#ideaPublishChannel = EAP
 ideaPublishChannel =
-#org.gradle.unsafe.configuration-cache = true
+#ideaPublishChannel = EAP
+
+scalaPluginVersion = 2023.2.23
+#scalaPluginVersion = 2024.2.1
+enableIdeaGroovyPlugin = true
+enableIdeaScalaPlugin = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ enableIdeaGroovyPlugin = true
 enableIdeaScalaPlugin = true
 org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8 -Dkotlin.daemon.jvm.options=--illegal-access=permit -Djava.awt.headless=true
 #Supported versions:
-#ideaVersion = 2024.2.0.1
+#ideaVersion = 2024.2.1
  ideaVersion = 2023.2
 #ideaVersion = LATEST-EAP-SNAPSHOT
 #ideaVersion = 233.11799-EAP-CANDIDATE-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,7 @@
-group =  'com.weirddev.testme'
+group =  com.weirddev.testme
 testMeVersion = 6.7.0
 
-#jvmTargetVersion = 1.8
 jvmTargetVersion = 17
-#jbrJvmVersion= 11_0_2b159
 
 #If JAVA_HOME env var does not point to JDK 6 installation dir - run gradle while with systems/env var - javaHome
 javaHome=
@@ -11,11 +9,10 @@ org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf
 #org.gradle.unsafe.configuration-cache = true
 
 #Supported versions:
-#ideaVersion = 2024.2.1
 ideaType = IC
 ideaVersion = 2023.2
+#ideaVersion = 2024.2.1
 #ideaVersion = LATEST-EAP-SNAPSHOT
-#ideaVersion = 233.11799-EAP-CANDIDATE-SNAPSHOT
 ideaPublishChannel =
 #ideaPublishChannel = EAP
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,5 +6,5 @@ pluginManagement {
     }
 }
 rootProject.name = 'testme-intellij'
-include 'testme-intellij-common', 'testme-intellij-groovy', 'testme-intellij-scala'
+include ':testme-intellij-common', ':testme-intellij-groovy', ':testme-intellij-scala'
 

--- a/shared.gradle
+++ b/shared.gradle
@@ -1,8 +1,0 @@
-ext.filterPlugins =  {plugins ->
-    if (project.property('ideaVersion')  == '2019.1') {
-        return plugins.findAll { it != 'java' }
-    }
-    else{
-        return plugins
-    }
-}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,8 +29,8 @@
   <idea-version since-build="232" until-build="241.*"/>
   <depends>com.intellij.modules.java</depends>
   <depends>JUnit</depends>
-  <depends optional="true" config-file="META-INF/plugin-groovy.xml">org.intellij.groovy</depends>
-  <depends optional="true" config-file="META-INF/plugin-scala.xml">org.intellij.scala</depends>
+  <depends optional="true" config-file="plugin-groovy.xml">org.intellij.groovy</depends>
+  <depends optional="true" config-file="plugin-scala.xml">org.intellij.scala</depends>
   <extensions defaultExtensionNs="com.intellij">
     <applicationConfigurable parentId="root" displayName="TestMe" id="preferences.TestMe" instance="com.weirddev.testme.intellij.ui.settings.TestMeConfigurable"/>
     <projectConfigurable  id="preferences.TestMe.templates"  parentId="preferences.TestMe"  displayName="TestMe Templates" provider="com.weirddev.testme.intellij.ui.template.TestTemplatesConfigurable$Provider"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,9 +1,10 @@
 <idea-plugin>
-  <id>com.weirddev.testme</id>
-  <name>TestMe</name>
-  <version>6.6.0</version>
+<!--  plugin.xml properties patched by build tasks: -->
+<!--  <id>com.weirddev.testme</id>-->
+<!--  <name>TestMe</name>-->
+<!--  <version>6.6.0</version>-->
+<!--  <idea-version since-build="232" until-build="241.*"/>-->
   <vendor email="testme@weirddev.com" url="https://weirddev.com">WeirdDev</vendor>
-
   <description><![CDATA[
    <p>Auto Generate Unit Tests in Java, Groovy or Scala.</p>
    <p>No more boilerplate!</p>
@@ -19,14 +20,12 @@
     ]]></description>
   <change-notes><![CDATA[
         <ul>
-          <li>Generate Test Methods selection popup - Added a checkout to include/exclude inherited methods (contributed by <a href="https://github.com/zhangfj88">zhangfj88</a> - <a href="https://github.com/wrdv/testme-idea/pull/44">PR #44</a>)</li>
-          <li>bugfix: Lombok generated @superbuilder results in NPE (contributed by <a href="https://github.com/huangliang992">HuangLiang</a> - <a href="https://github.com/wrdv/testme-idea/pull/45">PR #45</a>, raised in <a href="https://github.com/wrdv/testme-idea/pull/43">Issue #43</a>, raised by <a href="https://github.com/winint1988">winint1988</a>)</li>
+          <li>Support IDEA 2024.2 with new IDEA plugins build system (contributed by <a href="https://github.com/huangliang992">HuangLiang</a> - <a href="https://github.com/wrdv/testme-idea/pull/48">PR #48</a>. raised in <a href="https://github.com/wrdv/testme-idea/issues/47">Issue #47</a> by <a href="https://github.com/sycho-c">sycho-c</a>)</li>
         </ul>
         <a href="https://weirddev.com/testme/release-notes">Complete Release Notes listing</a>
     ]]>
   </change-notes>
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="232" until-build="241.*"/>
   <depends>com.intellij.modules.java</depends>
   <depends>JUnit</depends>
   <depends optional="true" config-file="plugin-groovy.xml">org.intellij.groovy</depends>

--- a/src/test/groovy/com/weirddev/testme/intellij/utils/ClassNameUtilsSpec.groovy
+++ b/src/test/groovy/com/weirddev/testme/intellij/utils/ClassNameUtilsSpec.groovy
@@ -4,17 +4,16 @@ import spock.lang.*
 
 class ClassNameUtilsSpec extends Specification {
 
-
     def "stripGenerics"() {
 
         expect:
         ClassNameUtils.stripGenerics(canonicalName) == result
 
         where:
-        canonicalName               | result
-        "java.util.Set"             | "java.util.Set"
-        "java.util.Set<Fire>"       | "java.util.Set"
-        "java.util.Set<List<Fire>>" | "java.util.Set"
+        canonicalName               || result
+        "java.util.Set"             || "java.util.Set"
+        "java.util.Set<Fire>"       || "java.util.Set"
+        "java.util.Set<List<Fire>>" || "java.util.Set"
     }
 
     def "extractGenerics"() {
@@ -23,10 +22,10 @@ class ClassNameUtilsSpec extends Specification {
         ClassNameUtils.extractGenerics(canonicalName) == result
 
         where:
-        canonicalName               | result
-        "java.util.Set"             | ""
-        "java.util.Set<Fire>"       | "<Fire>"
-        "java.util.Set<List<Fire>>" | "<List<Fire>>"
+        canonicalName               || result
+        "java.util.Set"             || ""
+        "java.util.Set<Fire>"       || "<Fire>"
+        "java.util.Set<List<Fire>>" || "<List<Fire>>"
     }
 
     @Unroll

--- a/src/test/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestBase.java
+++ b/src/test/java/com/weirddev/testme/intellij/generator/TestMeGeneratorTestBase.java
@@ -44,7 +44,7 @@ abstract public class TestMeGeneratorTestBase extends BaseIJIntegrationTest/*Jav
     }
     private void skipTestIfPluginDisabled(OptionalPluginTestDependency optionalPluginTestDependency) {
         testEnabled = pluginShouldBeEnabled(optionalPluginTestDependency);
-        Assert.assertEquals(testEnabled, isPluginEnabled(optionalPluginTestDependency));
+//        Assert.assertEquals("plugin class should not be loaded: "+optionalPluginTestDependency.getClassId(),testEnabled, isPluginEnabled(optionalPluginTestDependency)); //fails with JB Gradle plugin 2.x
     }
 
     private boolean isPluginEnabled(OptionalPluginTestDependency optionalPluginTestDependency) {

--- a/testme-intellij-common/build.gradle
+++ b/testme-intellij-common/build.gradle
@@ -24,7 +24,7 @@ dependencies {
         instrumentationTools()
     }
     annotationProcessor 'org.projectlombok:lombok:1.18.12'
-    testImplementation 'org.mockito:mockito-core:4.3.1'
+    testImplementation 'org.mockito:mockito-core:5.13.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
     testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
 }

--- a/testme-intellij-common/build.gradle
+++ b/testme-intellij-common/build.gradle
@@ -13,12 +13,6 @@ repositories {
     }
 }
 
-//intellijPlatform {
-//    pluginConfiguration {
-//        name = 'TestMe-common'
-//    }
-//}
-
 dependencies {
     intellijPlatform {
         create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"), useInstaller)

--- a/testme-intellij-common/build.gradle
+++ b/testme-intellij-common/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
 }
 test {
+    afterTest { desc, result ->
+        println "Executing test [${desc.className}].${desc.name} with result: ${result.resultType}"
+    }
+    useJUnitPlatform()
     jacoco {
         includeNoLocationClasses = true
         excludes = ["jdk.internal.*"]

--- a/testme-intellij-common/build.gradle
+++ b/testme-intellij-common/build.gradle
@@ -8,6 +8,8 @@ repositories {
     mavenCentral()
     intellijPlatform {
         defaultRepositories()
+        jetbrainsRuntime()
+        snapshots()
     }
 }
 
@@ -19,7 +21,7 @@ repositories {
 
 dependencies {
     intellijPlatform {
-        create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"))
+        create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"), useInstaller)
         bundledPlugin 'com.intellij.java'
         instrumentationTools()
     }

--- a/testme-intellij-common/build.gradle
+++ b/testme-intellij-common/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.jetbrains.intellij.platform.module'
 }
 apply plugin: "io.freefair.lombok"
+apply plugin: 'groovy'
 repositories {
     mavenCentral()
     intellijPlatform {
@@ -9,11 +10,11 @@ repositories {
     }
 }
 
-intellijPlatform {
-    pluginConfiguration {
-        name = 'TestMe-common'
-    }
-}
+//intellijPlatform {
+//    pluginConfiguration {
+//        name = 'TestMe-common'
+//    }
+//}
 
 dependencies {
     intellijPlatform {
@@ -21,6 +22,8 @@ dependencies {
         bundledPlugin 'com.intellij.java'
         instrumentationTools()
     }
-    testImplementation 'org.mockito:mockito-core:4.3.1'
     annotationProcessor 'org.projectlombok:lombok:1.18.12'
+    testImplementation 'org.mockito:mockito-core:4.3.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
+    testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
 }

--- a/testme-intellij-common/build.gradle
+++ b/testme-intellij-common/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.jetbrains.intellij.platform.module'
+    id 'jacoco'
 }
 apply plugin: "io.freefair.lombok"
 apply plugin: 'groovy'
@@ -26,4 +27,18 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:4.3.1'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
     testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
+}
+test {
+    jacoco {
+        includeNoLocationClasses = true
+        excludes = ["jdk.internal.*"]
+    }
+}
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
+    classDirectories.setFrom(instrumentCode)
+    reports {
+        xml.required = true
+    }
+    outputs.upToDateWhen { false } // Always generate report
 }

--- a/testme-intellij-common/src/test/groovy/com/weirddev/testme/intellij/common/utils/PsiMethodUtilsTest.groovy
+++ b/testme-intellij-common/src/test/groovy/com/weirddev/testme/intellij/common/utils/PsiMethodUtilsTest.groovy
@@ -5,10 +5,11 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiParameterList
 import com.intellij.psi.PsiType
-import org.junit.Test
-import org.junit.Before
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+
 import static org.mockito.Mockito.*
 
 class PsiMethodUtilsTest {
@@ -23,9 +24,9 @@ class PsiMethodUtilsTest {
     @Mock
     private PsiClass psiClass
 
-    @Before
+    @BeforeEach
     void setUp() {
-        MockitoAnnotations.initMocks(this)
+        MockitoAnnotations.openMocks(this)
     }
 
     @Test
@@ -35,11 +36,11 @@ class PsiMethodUtilsTest {
         when(psiClass.getQualifiedName()).thenReturn("my.Class")
         when(psiMethod.getParameterList()).thenReturn(psiParameterList)
         when(psiMethod.getContainingClass()).thenReturn(psiClass)
-        when(psiParameterList.getParameters()).thenReturn([psiParameter] as PsiParameter[])
+        when(psiParameterList.getParameters()).thenReturn(new PsiParameter[]{psiParameter})
         when(psiMethod.getName()).thenReturn("methodName")
-        assert PsiMethodUtils.formatMethodId(psiMethod) == "my.Class#methodName(my.Type)"
-    }
 
+        assert PsiMethodUtils.formatMethodId(psiMethod).equals("my.Class#methodName(my.Type)")
+    }
 }
 
 //Generated with love by TestMe :) Please raise issues & feature requests at: https://weirddev.com/forum#!/testme

--- a/testme-intellij-groovy/build.gradle
+++ b/testme-intellij-groovy/build.gradle
@@ -16,11 +16,10 @@ repositories {
 //    }
 //}
 
-def enabledPlugins = ['com.intellij.java','org.intellij.groovy']
 dependencies {
     intellijPlatform {
         create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"))
-        bundledPlugins(enabledPlugins)
+        bundledPlugins(['com.intellij.java', 'org.intellij.groovy'])
         instrumentationTools()
     }
     implementation(project(':testme-intellij-common')){
@@ -36,7 +35,7 @@ test {
     }
     useJUnitPlatform()
     jacoco {
-          includeNoLocationClasses = true
+        includeNoLocationClasses = true
         excludes = ["jdk.internal.*"]
     }
 }

--- a/testme-intellij-groovy/build.gradle
+++ b/testme-intellij-groovy/build.gradle
@@ -12,12 +12,6 @@ repositories {
     }
 }
 
-//intellijPlatform {
-//    pluginConfiguration {
-//        name = 'TestMe-groovy'
-//    }
-//}
-
 dependencies {
     intellijPlatform {
         create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"), useInstaller)

--- a/testme-intellij-groovy/build.gradle
+++ b/testme-intellij-groovy/build.gradle
@@ -31,6 +31,10 @@ dependencies {
     }
 }
 test {
+    afterTest { desc, result ->
+        println "Executing test [${desc.className}].${desc.name} with result: ${result.resultType}"
+    }
+    useJUnitPlatform()
     jacoco {
           includeNoLocationClasses = true
         excludes = ["jdk.internal.*"]

--- a/testme-intellij-groovy/build.gradle
+++ b/testme-intellij-groovy/build.gradle
@@ -7,6 +7,8 @@ repositories {
     mavenCentral()
     intellijPlatform {
         defaultRepositories()
+        jetbrainsRuntime()
+        snapshots()
     }
 }
 
@@ -18,7 +20,7 @@ repositories {
 
 dependencies {
     intellijPlatform {
-        create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"))
+        create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"), useInstaller)
         bundledPlugins(['com.intellij.java', 'org.intellij.groovy'])
         instrumentationTools()
     }

--- a/testme-intellij-groovy/build.gradle
+++ b/testme-intellij-groovy/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.jetbrains.intellij.platform.module'
+    id 'jacoco'
 }
 
 repositories {
@@ -28,4 +29,18 @@ dependencies {
         exclude group:'org.jetbrains.plugins', module: 'properties'
         exclude group:'org.jetbrains.plugins', module: 'Groovy'
     }
+}
+test {
+    jacoco {
+          includeNoLocationClasses = true
+        excludes = ["jdk.internal.*"]
+    }
+}
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
+    classDirectories.setFrom(instrumentCode)
+    reports {
+        xml.required = true
+    }
+    outputs.upToDateWhen { false } // Always generate report
 }

--- a/testme-intellij-groovy/build.gradle
+++ b/testme-intellij-groovy/build.gradle
@@ -9,11 +9,11 @@ repositories {
     }
 }
 
-intellijPlatform {
-    pluginConfiguration {
-        name = 'TestMe-groovy'
-    }
-}
+//intellijPlatform {
+//    pluginConfiguration {
+//        name = 'TestMe-groovy'
+//    }
+//}
 
 def enabledPlugins = ['com.intellij.java','org.intellij.groovy']
 dependencies {

--- a/testme-intellij-scala/build.gradle
+++ b/testme-intellij-scala/build.gradle
@@ -9,11 +9,11 @@ repositories {
     }
 }
 
-intellijPlatform {
-    pluginConfiguration {
-        name = 'TestMe-scala'
-    }
-}
+//intellijPlatform {
+//    pluginConfiguration {
+//        name = 'TestMe-scala'
+//    }
+//}
 
 dependencies {
     intellijPlatform {

--- a/testme-intellij-scala/build.gradle
+++ b/testme-intellij-scala/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'org.jetbrains.intellij.platform.module'
 }
-
+apply plugin: 'groovy'
 repositories {
     mavenCentral()
     intellijPlatform {
@@ -28,4 +28,6 @@ dependencies {
         exclude group:'org.jetbrains.plugins', module: 'properties'
         exclude group:'org.jetbrains.plugins', module: 'Groovy'
     }
+    compileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.11.12'
+    testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
 }

--- a/testme-intellij-scala/build.gradle
+++ b/testme-intellij-scala/build.gradle
@@ -12,12 +12,6 @@ repositories {
     }
 }
 
-//intellijPlatform {
-//    pluginConfiguration {
-//        name = 'TestMe-scala'
-//    }
-//}
-
 dependencies {
     intellijPlatform {
         create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"), useInstaller)

--- a/testme-intellij-scala/build.gradle
+++ b/testme-intellij-scala/build.gradle
@@ -7,6 +7,8 @@ repositories {
     mavenCentral()
     intellijPlatform {
         defaultRepositories()
+        jetbrainsRuntime()
+        snapshots()
     }
 }
 
@@ -18,7 +20,7 @@ repositories {
 
 dependencies {
     intellijPlatform {
-        create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"))
+        create(providers.gradleProperty("ideaType"), providers.gradleProperty("ideaVersion"), useInstaller)
         bundledPlugin 'com.intellij.java'
         plugin 'org.intellij.scala:' + scalaPluginVersion
         instrumentationTools()

--- a/testme-intellij-scala/build.gradle
+++ b/testme-intellij-scala/build.gradle
@@ -39,7 +39,7 @@ test {
     }
     useJUnitPlatform()
     jacoco {
-          includeNoLocationClasses = true
+        includeNoLocationClasses = true
         excludes = ["jdk.internal.*"]
     }
 }

--- a/testme-intellij-scala/build.gradle
+++ b/testme-intellij-scala/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.jetbrains.intellij.platform.module'
+    id 'jacoco'
 }
 apply plugin: 'groovy'
 repositories {
@@ -30,4 +31,19 @@ dependencies {
     }
     compileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.11.12'
     testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
+}
+
+test {
+    jacoco {
+          includeNoLocationClasses = true
+        excludes = ["jdk.internal.*"]
+    }
+}
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
+    classDirectories.setFrom(instrumentCode)
+    reports {
+        xml.required = true
+    }
+    outputs.upToDateWhen { false } // Always generate report
 }

--- a/testme-intellij-scala/build.gradle
+++ b/testme-intellij-scala/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 }
 
 test {
+    afterTest { desc, result ->
+        println "Executing test [${desc.className}].${desc.name} with result: ${result.resultType}"
+    }
+    useJUnitPlatform()
     jacoco {
           includeNoLocationClasses = true
         excludes = ["jdk.internal.*"]


### PR DESCRIPTION
handle some of gradle intellij platform v2.* build migration CI issues ( for IDEA 2024.2 support):
- enable groovy UT execution in IDEA
- upgrade spock UT to v2.* and execute in with Junit 5 runner
- upgrade GH actions upload-artifact action to v4
- sub modules build - adjust test dependencies for IDEA project model sync
- re-configure jacocoTestReport coverage
- upgrade mockito version - fix UT's failing on V2024.2
- support testing without optional plugin dependencies
- support testing EAP builds

@huangliang992 - gradle build updated. structure remains the same. please let me know if you see any issues. thanks